### PR TITLE
New branching strategy in ReadMe (pt-6)

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -2,9 +2,9 @@ name: Build and test
 
 on:
   push:
-    branches: [ "development" , "main" ]
+    branches: [ "integration" , "main" ]
   pull_request:
-    branches: [ "development" , "main" ]
+    branches: [ "integration" , "main" ]
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 

--- a/README.md
+++ b/README.md
@@ -58,22 +58,22 @@ Annotations follows a structure with 3 kinds of branches
 - Integration
 - Feature
 
-There is only _one_ Main branch and _one_ Integration branch.
+There is only _one_ **Main** branch and _one_ **Integration** branch.
 
-If you wish to develop on the project, you need to create a Feature branch - following below Branch Naming Conventions.
+If you wish to develop on the project, you need to create a **Feature** branch - following below Branch Naming Conventions.
 
-If your Feature branch needs integration with other Feature branches in order to be deployable, you need to merge these branches using the Integration branch.
+If your **Feature** branch needs integration with other **Feature** branches in order to be deployable, you need to merge these branches using the **Integration** branch.
 
-When the Integration branch is ready (up to date with Main, and with working additions from the Feature branches), the Integration branch can be merged into main.
+When the **Integration** branch is ready (up to date with **Main**, and with working additions from the **Feature** branches), the **Integration** branch can be merged into **Main**.
 
-If a Feature branch _does not_ need integration with other Feature branches and is deployable, it can be merged directly into the Main branch.
+If a **Feature** branch _does not_ need integration with other **Feature** branches and is deployable, it can be merged directly into the **Main** branch.
 
 ### Code Review Rules
-- When merging directly into Main from a Feature branch, at least 2 detailed peer code reviews are required on the Pull Request.
+- When merging directly into **Main** from a **Feature** branch, at least 2 detailed peer code reviews are required on the Pull Request.
 
-- When merging into the Integration branch, at least 2 detailed peer code reviews are needed for each merge.
+- When merging into the **Integration** branch, at least 2 detailed peer code reviews are needed for each merge.
 
-- When merging from the Integration branch, 2 peer code reviews are still needed, but do not need to be detailed, as they have already been reviewed in detail when merging to the Integration branch.
+- When merging into **Main** _from the **Integration** branch_, 2 peer code reviews are still needed, but do not need to be detailed, as they have already been reviewed in detail when merging to the **Integration** branch.
 
 ## Branch Naming Conventions
 

--- a/README.md
+++ b/README.md
@@ -53,22 +53,34 @@ The runnable projects within the solution are:
 # Contribution guidelines
 
 ## Branching Strategy
+Annotations follows a structure with 3 kinds of branches
+- Main
+- Integration
+- Feature
 
-![Example of gitflow branching strategy](https://raw.githubusercontent.com/ITU-ISE2025-GROUP8-PT/Annotations/bf03ac84a553c1dc77d78d41ace43b4f3a55bb8f/gitflow_branching_strategy.png)
+There is only _one_ Main branch and _one_ Integration branch.
 
-- Development of new code is produced in feature branches. Features are continuously added to the development branch through pull requests with reviews made by other team members.
-- Typically we will demonstrate the state of the project at Sprint reviews using the development branch. 
-- Once we have sufficient material to warrant a release. We will work to stage an increment of mature features. We will create a special branch for this purpose. 
-- The increment goes through additional testing and review before we agree to deploy it to production. 
+If you wish to develop on the project, you need to create a Feature branch - following below Branch Naming Conventions.
 
-Image Source: https://blog.levelupcoding.com/p/luc-68-navigating-software-updates-a-closer-look-at-deployment-strategies
+If your Feature branch needs integration with other Feature branches in order to be deployable, you need to merge these branches using the Integration branch.
+
+When the Integration branch is ready (up to date with Main, and with working additions from the Feature branches), the Integration branch can be merged into main.
+
+If a Feature branch _does not_ need integration with other Feature branches and is deployable, it can be merged directly into the Main branch.
+
+### Code Review Rules
+- When merging directly into Main from a Feature branch, at least 2 detailed peer code reviews are required on the Pull Request.
+
+- When merging into the Integration branch, at least 2 detailed peer code reviews are needed for each merge.
+
+- When merging from the Integration branch, 2 peer code reviews are still needed, but do not need to be detailed, as they have already been reviewed in detail when merging to the Integration branch.
 
 ## Branch Naming Conventions
 
 All branches follow the convention of
 
 ```bash
-feature/[function_of_the_feature]/[possible_version_number]
+feature/[function_of_the_feature_and_ticket_id]/[possible_version_number]
 
 bugfix/[what_to_fix]
 
@@ -79,7 +91,7 @@ test/[what_to_test]
 
 Examples of naming branches: 
 
-- `feature/upload-image`
+- `feature/upload-image-pt-1`
 - `bugfix/misplaced-css-5`
 - `refactor/file-system`
 - `test/user-registration`


### PR DESCRIPTION
The new branching stragety has been explained in the ReadMe file. I have also changed the build'n'test workflow, as development branch is now called integration branch.

Please all read through the new addition to the ReadMe, as we all need to know this :3

Also note that development branch in the repo has changed name to 'integration'.