### PR TITLE
Feature/image retrival pt 54

### DIFF
--- a/Annotations.API/Groups/ImagesGroup.cs
+++ b/Annotations.API/Groups/ImagesGroup.cs
@@ -60,9 +60,6 @@ public static class ImagesGroup
             }
             else
             {
-                //this connectionString was based on Nickie's own local Azurite - replace this with your own connection string
-                //TODO: make connectionString not local
-                
 
                 //fileExtension will always be a proper fileExtension because of the ValidateImage method
                 string fileExtension = "empty";//TODO: dont do this

--- a/Annotations.API/Groups/ImagesGroup.cs
+++ b/Annotations.API/Groups/ImagesGroup.cs
@@ -12,6 +12,11 @@ public static class ImagesGroup
 {
     private static int counter = 0;//change this - it gets reset every time the program resets
     private record ValidationResponse(bool Success, string Message);
+    //TODO: DONT DO THIS
+    private static string connectionString =
+        "AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;";
+    static BlobServiceClient blobServiceClient = new BlobServiceClient(connectionString);
+    static BlobContainerClient containerClient = blobServiceClient.GetBlobContainerClient("images");
     /// <summary>
     /// Helping method that validates an image based on type, size, and also checks if it even contains anything
     /// Images can be JPEG, PNG and JPG, and everything else gets rejected
@@ -57,10 +62,7 @@ public static class ImagesGroup
             {
                 //this connectionString was based on Nickie's own local Azurite - replace this with your own connection string
                 //TODO: make connectionString not local
-                var connectionString =
-                    "AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;DefaultEndpointsProtocol=http;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;QueueEndpoint=http://127.0.0.1:10001/devstoreaccount1;TableEndpoint=http://127.0.0.1:10002/devstoreaccount1;";
-                BlobServiceClient blobServiceClient = new BlobServiceClient(connectionString);
-                BlobContainerClient containerClient = blobServiceClient.GetBlobContainerClient("images");
+                
 
                 //fileExtension will always be a proper fileExtension because of the ValidateImage method
                 string fileExtension = "empty";//TODO: dont do this
@@ -88,7 +90,7 @@ public static class ImagesGroup
 
         }).DisableAntiforgery();
         //ellers ved billedfil brug da
-        pathBuilder.MapGet("/{imageId}", async ([FromRoute] int imageId, AnnotationsDbContext context) =>
+        pathBuilder.MapGet("/{imageId}", async ([FromRoute] string imageId, AnnotationsDbContext context) =>
         {
             //indsæt adgangskontol her 🐿️
             var cts = new CancellationTokenSource(5000);
@@ -104,6 +106,7 @@ public static class ImagesGroup
             }
             catch (OperationCanceledException)
             { return Results.StatusCode(408); }
+            
         });
 
         pathBuilder.MapGet("/exception",

--- a/Annotations.API/Groups/ImagesGroup.cs
+++ b/Annotations.API/Groups/ImagesGroup.cs
@@ -60,7 +60,6 @@ public static class ImagesGroup
             }
             else
             {
-
                 //fileExtension will always be a proper fileExtension because of the ValidateImage method
                 string fileExtension = "empty";//TODO: dont do this
                 switch (image.ContentType)

--- a/Annotations.API/Groups/ImagesGroup.cs
+++ b/Annotations.API/Groups/ImagesGroup.cs
@@ -95,17 +95,20 @@ public static class ImagesGroup
             //indsæt adgangskontol her 🐿️
             var cts = new CancellationTokenSource(5000);
 
-            try
+            string[] ArrayOfFileExtension = {"jpg", "jpeg", "png"};
+            foreach (string fileExtension in ArrayOfFileExtension)
             {
-                var image = await context.Images.FindAsync(imageId, cts.Token);
-                if (image is null)
+                BlobClient blobClient = containerClient.GetBlobClient(imageId + "." + fileExtension);
+                if (!blobClient.Exists(cts.Token).ToString().Contains("404"))
                 {
-                    return Results.NotFound();
+                    using var memoryStream = new MemoryStream();
+                    await blobClient.DownloadToAsync(memoryStream);
+                    return Results.File(memoryStream.ToArray(), "image/" + fileExtension);
                 }
-                return Results.File(image.ImageData, "image/png");
+
             }
-            catch (OperationCanceledException)
-            { return Results.StatusCode(408); }
+            Console.WriteLine("Cannot find file");
+            return Results.StatusCode(408);
             
         });
 


### PR DESCRIPTION
Before approving this pull request, the previous pull request regarding image upload must be closed.

This is the updated way of retrieving images from Azure blob storage. The imageID used is currently a string, but that can easily be changed if needed. If there are multiple images with the same name/ID but different formats, JPEG and JPGs are prioritised over PNG. This could technically be changed, but this should not be able to happen in the first place. 
The only reason this is possible is that emulator itseld doesn't stop when the program stops running, which means the same database is used while the counter gets reset. 

The connection string has also been changed to be the default one, which should mean that you don't need to change the connection string in the code. You just need Azurite running in the background.

Please test out if you can upload/retrieve images on your own computer/local database.

This is to finish the ticket regarding updating the image database