### PR TITLE
Feature/image deletion

### DIFF
--- a/Annotations.API/Groups/ImagesGroup.cs
+++ b/Annotations.API/Groups/ImagesGroup.cs
@@ -18,6 +18,8 @@ public static class ImagesGroup
         "AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;";
     private static BlobServiceClient blobServiceClient = new BlobServiceClient(connectionString);
     private static BlobContainerClient containerClient = blobServiceClient.GetBlobContainerClient("images");
+    private static string[] ArrayOfFileExtension = {"jpg", "jpeg", "png"};
+
     /// <summary>
     /// Helping method that validates an image based on type, size, and also checks if it even contains anything
     /// Images can be JPEG, PNG and JPG, and everything else gets rejected
@@ -92,7 +94,6 @@ public static class ImagesGroup
             //indsæt adgangskontol her 🐿️
             var cts = new CancellationTokenSource(5000);
 
-            string[] ArrayOfFileExtension = {"jpg", "jpeg", "png"};
             foreach (string fileExtension in ArrayOfFileExtension)
             {
                 BlobClient blobClient = containerClient.GetBlobClient(imageId + "." + fileExtension);
@@ -112,7 +113,6 @@ public static class ImagesGroup
         {
             var cts = new CancellationTokenSource(5000);
 
-            string[] ArrayOfFileExtension = {"jpg", "jpeg", "png"};
             foreach (string fileExtension in ArrayOfFileExtension)
             {
                 BlobClient blobClient = containerClient.GetBlobClient(imageId + "." + fileExtension);

--- a/Annotations.API/Groups/ImagesGroup.cs
+++ b/Annotations.API/Groups/ImagesGroup.cs
@@ -72,17 +72,14 @@ public static class ImagesGroup
             {
                 //fileExtension will always be a proper fileExtension because of the ValidateImage method
                 string fileExtension = "empty";//TODO: dont do this
-                switch (image.ContentType)
+
+                foreach (string Filename in ArrayOfFileExtension)
                 {
-                    case "image/jpeg":
-                        fileExtension = ".jpeg";
+                    if (image.ContentType == "image/" + Filename)
+                    {
+                        fileExtension = Filename;
                         break;
-                    case "image/png":
-                        fileExtension = ".png";
-                        break;
-                    case "image/jpg":
-                        fileExtension = ".jpg";
-                        break;
+                    }
                 }
                 
                 BlobClient imageBlobClient = containerClient.GetBlobClient($"{counter}{fileExtension}");

--- a/Annotations.API/Groups/ImagesGroup.cs
+++ b/Annotations.API/Groups/ImagesGroup.cs
@@ -4,6 +4,7 @@ using Annotations.Core.Entities;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using Azure.Storage.Blobs;
+using Azure.Storage.Blobs.Models;
 using Microsoft.AspNetCore.Http.HttpResults;
 
 namespace Annotations.API.Groups;
@@ -104,7 +105,7 @@ public static class ImagesGroup
 
             }
             Console.WriteLine("Cannot find file");
-            return Results.StatusCode(408);
+            return Results.StatusCode(404);
             
         });
         pathBuilder.MapPost("/delete", async (string imageId) =>
@@ -117,14 +118,14 @@ public static class ImagesGroup
                 BlobClient blobClient = containerClient.GetBlobClient(imageId + "." + fileExtension);
                 if (!blobClient.Exists(cts.Token).ToString().Contains("404"))
                 {
-                    await blobClient.DeleteAsync();
+                    await blobClient.DeleteAsync(snapshotsOption: DeleteSnapshotsOption.IncludeSnapshots);
                     Console.WriteLine("deleted");
                     return Results.StatusCode(204);
                 }
 
             }
             Console.WriteLine("Cannot find file");
-            return Results.StatusCode(408);
+            return Results.StatusCode(404);
 
         }).DisableAntiforgery();
 

--- a/Annotations.API/Groups/ImagesGroup.cs
+++ b/Annotations.API/Groups/ImagesGroup.cs
@@ -60,7 +60,6 @@ public static class ImagesGroup
             }
             else
             {
-
                 //fileExtension will always be a proper fileExtension because of the ValidateImage method
                 string fileExtension = "empty";//TODO: dont do this
                 switch (image.ContentType)

--- a/Annotations.API/Groups/ImagesGroup.cs
+++ b/Annotations.API/Groups/ImagesGroup.cs
@@ -18,7 +18,7 @@ public static class ImagesGroup
         "AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;";
     private static BlobServiceClient blobServiceClient = new BlobServiceClient(connectionString);
     private static BlobContainerClient containerClient = blobServiceClient.GetBlobContainerClient("images");
-    private static string[] ArrayOfFileExtension = {"jpg", "jpeg", "png"};
+    private static string[] ArrayOfFileExtension = {"png", "jpg", "jpeg"};
 
     /// <summary>
     /// Helping method that validates an image based on type, size, and also checks if it even contains anything
@@ -28,10 +28,7 @@ public static class ImagesGroup
     /// <returns>ValidationResponse - a record that contains a boolean of whether the image is validated, and a message that describes either what went wrong, or that it was successful</returns>
     private static ValidationResponse ValidateImage(IFormFile file)//temporary location
     {
-        if (file.ContentType != "image/jpeg" && file.ContentType != "image/png" &&  file.ContentType != "image/jpg")
-        {
-            return new ValidationResponse(false, "File is not a valid image.");
-        } 
+        
         if (file.Length > 50 * 1024 * 1024) {//50MB
             return new ValidationResponse(false, "File is too large.");
         }
@@ -39,8 +36,17 @@ public static class ImagesGroup
         { 
             return new ValidationResponse(false, "File doesn't exist.");
         }
-        //upload image to db
-        return new ValidationResponse(true ,"Uploaded image successfully.");
+        foreach (string FileExtension in ArrayOfFileExtension)
+        {
+            if (file.ContentType.Contains(FileExtension))
+            {
+                //if the image is the correct type, it will be uploaded, since it fulfills the other criterias
+                //upload image to db
+                return new ValidationResponse(true ,"Uploaded image successfully.");
+            }
+        }
+        //if the code reaches this point, then the file type is none of the permitted file types, so an error is thrown
+        return new ValidationResponse(false, "File is not a valid image.");
         
     }
     public static void MapEndpoints(RouteGroupBuilder pathBuilder)
@@ -59,6 +65,7 @@ public static class ImagesGroup
             if (!response.Success)
             {
                 Console.WriteLine("rejecting image");
+                Console.WriteLine(response.Message);
                 //TODO: how should the end user see this?
             }
             else

--- a/Annotations.API/Groups/ImagesGroup.cs
+++ b/Annotations.API/Groups/ImagesGroup.cs
@@ -89,22 +89,23 @@ public static class ImagesGroup
 
         }).DisableAntiforgery();
         //ellers ved billedfil brug da
-        pathBuilder.MapGet("/{imageId}", async ([FromRoute] string imageId, AnnotationsDbContext context) =>
+        pathBuilder.MapGet("/{imageId}", async ([FromRoute] string imageId) =>
         {
-            //indsæt adgangskontol her 🐿️
+            //insert password restrictions here 🐿️
             var cts = new CancellationTokenSource(5000);
 
-            foreach (string fileExtension in ArrayOfFileExtension)
+            foreach (string fileExtension in ArrayOfFileExtension)//takes all of the types of files we allow and see if an image of that format exists with the id
             {
                 BlobClient blobClient = containerClient.GetBlobClient(imageId + "." + fileExtension);
-                if (!blobClient.Exists(cts.Token).ToString().Contains("404"))
+                if (!blobClient.Exists(cts.Token).ToString().Contains("404"))//checks if the blobClient is empty/couldn't find the image of that format
                 {
                     using var memoryStream = new MemoryStream();
                     await blobClient.DownloadToAsync(memoryStream);
-                    return Results.File(memoryStream.ToArray(), "image/" + fileExtension);
+                    return Results.File(memoryStream.ToArray(), "image/" + fileExtension);//because it is a return statement the for-loop will not continue after finding the image
                 }
 
             }
+            //will only reach here if it cannot find an image with the id of the correct file type, or else the request will terminate inside the for-loop
             Console.WriteLine("Cannot retrieve image because it doesn't exist");
             return Results.StatusCode(404);
             

--- a/Annotations.API/Groups/ImagesGroup.cs
+++ b/Annotations.API/Groups/ImagesGroup.cs
@@ -66,6 +66,7 @@ public static class ImagesGroup
             {
                 Console.WriteLine("rejecting image");
                 Console.WriteLine(response.Message);
+                return Results.StatusCode(422);
                 //TODO: how should the end user see this?
             }
             else
@@ -97,6 +98,8 @@ public static class ImagesGroup
                 {
                     await imageBlobClient.UploadAsync(fileStream, overwrite: true);
                 }
+
+                return Results.StatusCode(200);
             }
 
 

--- a/Annotations.API/Groups/ImagesGroup.cs
+++ b/Annotations.API/Groups/ImagesGroup.cs
@@ -104,7 +104,7 @@ public static class ImagesGroup
                 }
 
             }
-            Console.WriteLine("Cannot find file");
+            Console.WriteLine("Cannot retrieve image because it doesn't exist");
             return Results.StatusCode(404);
             
         });
@@ -119,12 +119,12 @@ public static class ImagesGroup
                 if (!blobClient.Exists(cts.Token).ToString().Contains("404"))
                 {
                     await blobClient.DeleteAsync(snapshotsOption: DeleteSnapshotsOption.IncludeSnapshots);
-                    Console.WriteLine("deleted");
+                    Console.WriteLine("image deleted successfully");
                     return Results.StatusCode(204);
                 }
 
             }
-            Console.WriteLine("Cannot find file");
+            Console.WriteLine("Cannot delete image because it doesn't exist");
             return Results.StatusCode(404);
 
         }).DisableAntiforgery();

--- a/Annotations.API/Groups/ImagesGroup.cs
+++ b/Annotations.API/Groups/ImagesGroup.cs
@@ -77,7 +77,7 @@ public static class ImagesGroup
                 {
                     if (image.ContentType == "image/" + Filename)
                     {
-                        fileExtension = Filename;
+                        fileExtension = "." + Filename;
                         break;
                     }
                 }

--- a/Annotations.API/Groups/ImagesGroup.cs
+++ b/Annotations.API/Groups/ImagesGroup.cs
@@ -15,8 +15,8 @@ public static class ImagesGroup
     //TODO: DONT DO THIS
     private static string connectionString =
         "AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;";
-    static BlobServiceClient blobServiceClient = new BlobServiceClient(connectionString);
-    static BlobContainerClient containerClient = blobServiceClient.GetBlobContainerClient("images");
+    private static BlobServiceClient blobServiceClient = new BlobServiceClient(connectionString);
+    private static BlobContainerClient containerClient = blobServiceClient.GetBlobContainerClient("images");
     /// <summary>
     /// Helping method that validates an image based on type, size, and also checks if it even contains anything
     /// Images can be JPEG, PNG and JPG, and everything else gets rejected
@@ -107,6 +107,26 @@ public static class ImagesGroup
             return Results.StatusCode(408);
             
         });
+        pathBuilder.MapPost("/delete", async (string imageId) =>
+        {
+            var cts = new CancellationTokenSource(5000);
+
+            string[] ArrayOfFileExtension = {"jpg", "jpeg", "png"};
+            foreach (string fileExtension in ArrayOfFileExtension)
+            {
+                BlobClient blobClient = containerClient.GetBlobClient(imageId + "." + fileExtension);
+                if (!blobClient.Exists(cts.Token).ToString().Contains("404"))
+                {
+                    await blobClient.DeleteAsync();
+                    Console.WriteLine("deleted");
+                    return Results.StatusCode(204);
+                }
+
+            }
+            Console.WriteLine("Cannot find file");
+            return Results.StatusCode(408);
+
+        }).DisableAntiforgery();
 
         pathBuilder.MapGet("/exception",
             () =>

--- a/Annotations.API/Groups/ImagesGroup.cs
+++ b/Annotations.API/Groups/ImagesGroup.cs
@@ -124,7 +124,7 @@ public static class ImagesGroup
             
         });
         
-        pathBuilder.MapPost("/delete", async (string imageId) =>
+        pathBuilder.MapDelete("/{imageId}", async (string imageId) =>
         {
             var cts = new CancellationTokenSource(5000);
 


### PR DESCRIPTION
**This pull request may not be accepted before Feature/image endpoint pt 24 2!!!!**

Image deletion has now been implemented based on Azurite. It's possible to delete images by imageid. exceptions has been handled, but as stated in the other pull requests some security is lacking.

There has been some refactoring so there is an array of file extensions, and if any file types are added or removed from that array, then that should be reflected in all other endpoints.