### PR TITLE
Added Azure Blob Storage Dependency

### DIFF
--- a/Annotations.API.Tests/Properties/launchSettings.json
+++ b/Annotations.API.Tests/Properties/launchSettings.json
@@ -1,0 +1,12 @@
+{
+  "profiles": {
+    "Annotations.API.Tests": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      },
+      "applicationUrl": "https://localhost:60908;http://localhost:60909"
+    }
+  }
+}

--- a/Annotations.API/Annotations.API.csproj
+++ b/Annotations.API/Annotations.API.csproj
@@ -4,15 +4,20 @@
     <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
+    <UserSecretsId>55beb8d6-51c1-4fd7-8f6a-baa0b0acb6f3</UserSecretsId>
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Azure.Data.Tables" Version="12.9.1" />
     <PackageReference Include="Azure.Storage.Blobs" Version="12.24.0" />
+    <PackageReference Include="Azure.Storage.Files.Shares" Version="12.20.1" />
+    <PackageReference Include="Azure.Storage.Queues" Version="12.20.1" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.10" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.Extensions.Azure" Version="1.7.6" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="7.3.1" />
   </ItemGroup>
 

--- a/Annotations.API/AzureClientFactoryBuilderExtensions.cs
+++ b/Annotations.API/AzureClientFactoryBuilderExtensions.cs
@@ -1,0 +1,44 @@
+using Azure.Core.Extensions;
+using Azure.Data.Tables;
+using Azure.Storage.Blobs;
+using Azure.Storage.Queues;
+using Microsoft.Extensions.Azure;
+
+internal static class AzureClientFactoryBuilderExtensions
+{
+    public static IAzureClientBuilder<BlobServiceClient, BlobClientOptions> AddBlobServiceClient(this AzureClientFactoryBuilder builder, string serviceUriOrConnectionString, bool preferMsi = true)
+    {
+        if (preferMsi && Uri.TryCreate(serviceUriOrConnectionString, UriKind.Absolute, out Uri? serviceUri))
+        {
+            return builder.AddBlobServiceClient(serviceUri);
+        }
+        else
+        {
+            return BlobClientBuilderExtensions.AddBlobServiceClient(builder, serviceUriOrConnectionString);
+        }
+    }
+
+    public static IAzureClientBuilder<QueueServiceClient, QueueClientOptions> AddQueueServiceClient(this AzureClientFactoryBuilder builder, string serviceUriOrConnectionString, bool preferMsi = true)
+    {
+        if (preferMsi && Uri.TryCreate(serviceUriOrConnectionString, UriKind.Absolute, out Uri? serviceUri))
+        {
+            return builder.AddQueueServiceClient(serviceUri);
+        }
+        else
+        {
+            return QueueClientBuilderExtensions.AddQueueServiceClient(builder, serviceUriOrConnectionString);
+        }
+    }
+
+    public static IAzureClientBuilder<TableServiceClient, TableClientOptions> AddTableServiceClient(this AzureClientFactoryBuilder builder, string serviceUriOrConnectionString, bool preferMsi = true)
+    {
+        if (preferMsi && Uri.TryCreate(serviceUriOrConnectionString, UriKind.Absolute, out Uri? serviceUri))
+        {
+            return builder.AddTableServiceClient(serviceUri);
+        }
+        else
+        {
+            return TableClientBuilderExtensions.AddTableServiceClient(builder, serviceUriOrConnectionString);
+        }
+    }
+}

--- a/Annotations.API/Program.cs
+++ b/Annotations.API/Program.cs
@@ -29,11 +29,12 @@ builder.Services.AddDbContext<AnnotationsDbContext>((serviceProvider, options) =
 });
 
 builder.Services.AddAntiforgery();
+
 builder.Services.AddAzureClients(clientBuilder =>
 {
-    clientBuilder.AddBlobServiceClient(builder.Configuration["AzureStorageConnection:blobServiceUri"]!).WithName("AzureStorageConnection");
-    clientBuilder.AddQueueServiceClient(builder.Configuration["AzureStorageConnection:queueServiceUri"]!).WithName("AzureStorageConnection");
-    clientBuilder.AddTableServiceClient(builder.Configuration["AzureStorageConnection:tableServiceUri"]!).WithName("AzureStorageConnection");
+    clientBuilder.AddBlobServiceClient(builder.Configuration["AzureStorageConnection"]!);
+    clientBuilder.AddQueueServiceClient(builder.Configuration["AzureStorageConnection"]!);
+    clientBuilder.AddTableServiceClient(builder.Configuration["AzureStorageConnection"]!);
 });
 var app = builder.Build();
 

--- a/Annotations.API/Program.cs
+++ b/Annotations.API/Program.cs
@@ -3,8 +3,7 @@ using Annotations.API.Groups;
 using Annotations.Core.Entities;
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
-// using Azure.Storage.Blobs;
-// using System.Threading.Tasks;
+using Microsoft.Extensions.Azure;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -30,6 +29,12 @@ builder.Services.AddDbContext<AnnotationsDbContext>((serviceProvider, options) =
 });
 
 builder.Services.AddAntiforgery();
+builder.Services.AddAzureClients(clientBuilder =>
+{
+    clientBuilder.AddBlobServiceClient(builder.Configuration["AzureStorageConnection:blobServiceUri"]!).WithName("AzureStorageConnection");
+    clientBuilder.AddQueueServiceClient(builder.Configuration["AzureStorageConnection:queueServiceUri"]!).WithName("AzureStorageConnection");
+    clientBuilder.AddTableServiceClient(builder.Configuration["AzureStorageConnection:tableServiceUri"]!).WithName("AzureStorageConnection");
+});
 var app = builder.Build();
 
 

--- a/Annotations.API/Properties/serviceDependencies.json
+++ b/Annotations.API/Properties/serviceDependencies.json
@@ -1,0 +1,11 @@
+{
+  "dependencies": {
+    "secrets1": {
+      "type": "secrets"
+    },
+    "storage1": {
+      "type": "storage",
+      "connectionId": "AzureStorageConnection"
+    }
+  }
+}

--- a/Annotations.API/Properties/serviceDependencies.local.json
+++ b/Annotations.API/Properties/serviceDependencies.local.json
@@ -1,0 +1,12 @@
+{
+  "dependencies": {
+    "secrets1": {
+      "type": "secrets.user"
+    },
+    "storage1": {
+      "secretStore": "LocalSecretsFile",
+      "type": "storage.emulator",
+      "connectionId": "AzureStorageConnection"
+    }
+  }
+}


### PR DESCRIPTION
We created these two commits "in class". 

- We add Azure Storage clients for blob, queue and table storage. 
- All clients use a single secret to connect: "AzureStorageConnection". Set a user secret with the default Azurite connection string to get started as a developer. 
- ImageGroup has been updated to use the new pattern. 

Command for setting the user secret for `Annotations.API` project:

```
dotnet user-secrets set "AzureStorageConnection" <value>
```