### PR TITLE
feature/orchard-core-auth-pt-14

### DIFF
--- a/Annotations.API/Annotations.API.csproj
+++ b/Annotations.API/Annotations.API.csproj
@@ -19,6 +19,7 @@
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Azure" Version="1.7.6" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="7.3.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.14" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Annotations.API/Groups/ImagesGroup.cs
+++ b/Annotations.API/Groups/ImagesGroup.cs
@@ -48,10 +48,7 @@ public static class ImagesGroup
     }
     public static void MapEndpoints(RouteGroupBuilder pathBuilder)
     {
-        pathBuilder.MapGet("/", () => "Upload an image here!");
-
-       
-        
+        pathBuilder.RequireAuthorization();
         
         //This is the upload endpoint where the image first gets validated, and then gets uploaded into your local Azurite BlobStorage
         //The image gets saved in the database as the same file type it was uploaded as
@@ -94,7 +91,7 @@ public static class ImagesGroup
             }
 
 
-        }).DisableAntiforgery();
+        });
         //ellers ved billedfil brug da
         pathBuilder.MapGet("/{imageId}", async ([FromRoute] string imageId, [FromServices] IAzureClientFactory<BlobServiceClient> clientFactory) =>
         {
@@ -144,7 +141,7 @@ public static class ImagesGroup
             Console.WriteLine("Cannot delete image because it doesn't exist");
             return Results.StatusCode(404);
 
-        }).DisableAntiforgery();
+        });
 
         pathBuilder.MapGet("/exception",
             () =>

--- a/Annotations.API/Groups/ImagesGroup.cs
+++ b/Annotations.API/Groups/ImagesGroup.cs
@@ -149,5 +149,10 @@ public static class ImagesGroup
                 throw new InvalidOperationException(
                     "Exception has been raised in the API. Look for further details in the log.");
             });
+
+        pathBuilder.MapGet("/APITest", () =>
+        {
+            return new string[] { "1", "2", "3", "Dette er en prøve" };
+        });
     }
 }

--- a/Annotations.API/Program.cs
+++ b/Annotations.API/Program.cs
@@ -4,6 +4,7 @@ using Annotations.Core.Entities;
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Azure;
+using Microsoft.IdentityModel.Tokens;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -28,6 +29,19 @@ builder.Services.AddDbContext<AnnotationsDbContext>((serviceProvider, options) =
     options.UseSqlite(connection);
 });
 
+// Add services to the container.
+builder.Services.AddAuthentication("Bearer")
+    .AddJwtBearer("Bearer", jwtOptions =>
+    {
+        jwtOptions.Authority = builder.Configuration["jwt:Authority"] ?? throw new InvalidOperationException("JWT Authority not found");
+        jwtOptions.Audience = builder.Configuration["jwt:Audience"] ?? throw new InvalidOperationException("JWT Audience not found");;
+        jwtOptions.TokenValidationParameters = new TokenValidationParameters
+        {
+            ValidateIssuerSigningKey = true,
+        };
+    });
+
+builder.Services.AddAuthorization();
 builder.Services.AddAntiforgery();
 
 builder.Services.AddAzureClients(clientBuilder =>

--- a/Annotations.API/Properties/launchSettings.json
+++ b/Annotations.API/Properties/launchSettings.json
@@ -9,22 +9,22 @@
     }
   },
   "profiles": {
-    "http": {
-      "commandName": "Project",
-      "dotnetRunMessages": true,
-      "launchBrowser": true,
-      "launchUrl": "swagger",
-      "applicationUrl": "http://localhost:5084",
-      "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
-      }
-    },
     "https": {
       "commandName": "Project",
       "dotnetRunMessages": true,
       "launchBrowser": true,
       "launchUrl": "swagger",
       "applicationUrl": "https://localhost:7250;http://localhost:5084",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "http": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "launchUrl": "swagger",
+      "applicationUrl": "http://localhost:5084",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }

--- a/Annotations.API/appsettings.json
+++ b/Annotations.API/appsettings.json
@@ -8,5 +8,9 @@
   "ConnectionStrings": {
     "DefaultConnection": "Data Source=Data/testData.db"
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "jwt": {
+    "Audience": "https://localhost:7250/",
+    "Authority": "https://localhost:5001/"
+  }
 }

--- a/Annotations.Blazor/Annotations.Blazor.csproj
+++ b/Annotations.Blazor/Annotations.Blazor.csproj
@@ -1,13 +1,18 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
+    <UserSecretsId>83d66daa-a814-4d3f-919e-ff9fd2394048</UserSecretsId>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="MatBlazor" Version="2.10.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="8.0.14" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.Authorization" Version="8.0.14" />
+    <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.6.1" />
+    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="8.6.1" />
   </ItemGroup>
 
 </Project>

--- a/Annotations.Blazor/Components/Pages/ApiAccess.razor
+++ b/Annotations.Blazor/Components/Pages/ApiAccess.razor
@@ -1,0 +1,47 @@
+﻿@page "/ApiAccess"
+@using Microsoft.AspNetCore.Authentication
+@using Microsoft.AspNetCore.Authorization
+@using System.Text.Json;
+@inject IHttpClientFactory ClientFactory
+@inject IHttpContextAccessor httpContextAccessor
+@attribute [Authorize]
+
+<PageTitle>ApiAccesse</PageTitle>
+
+<h1>API Access test</h1>
+
+@if (story == null)
+{
+    <p><em>Loading...</em></p>
+}
+else
+{
+    <ul>
+        @foreach (var word in story)
+        {
+            <li>@word</li>
+        }
+    </ul>
+}
+
+
+@code {
+    private string[]? story;
+
+    protected override async Task OnInitializedAsync()
+    {
+        var httpContext = httpContextAccessor.HttpContext ?? throw new InvalidOperationException("No HttpContext available");
+
+        var accessToken = await httpContext.GetTokenAsync("access_token") ?? throw new InvalidOperationException("No access_token was saved");
+
+        var client = ClientFactory.CreateClient();
+        client.BaseAddress = new("https://localhost:7250");
+
+        using var requestMessage = new HttpRequestMessage(HttpMethod.Get, "/images/apitest");
+        requestMessage.Headers.Authorization = new("Bearer", accessToken);
+
+        using var response = await client.SendAsync(requestMessage);
+        story = await response.Content.ReadFromJsonAsync<string[]>();
+    }
+
+}

--- a/Annotations.Blazor/Components/Pages/Home.razor
+++ b/Annotations.Blazor/Components/Pages/Home.razor
@@ -1,5 +1,7 @@
 ﻿@page "/"
 @using MatBlazor
+@implements IDisposable
+@inject NavigationManager Navigation
 
 <PageTitle>Home</PageTitle>
 
@@ -10,11 +12,39 @@
 This is a template Blazor Application, including some functionality intended for you to get familiar with the Blazor framework. 
 Play around with it as needed!
 
-
+<AuthorizeView>
+    <Authorized>
+        <form action="authentication/logout" method="post">
+            <AntiforgeryToken />
+            <input type="hidden" name="ReturnUrl" value="@currentUrl" />
+            <MatButton class="loginbutton" type="submit">Sign out</MatButton>
+        </form>
+    </Authorized>
+    <NotAuthorized>
+        <MatButtonLink class="loginbutton" Href="authentication/login">Login</MatButtonLink>
+    </NotAuthorized>
+</AuthorizeView>
     
-<MatButtonLink class="loginbutton" Href="/auth/login">Login</MatButtonLink>
+
 <MatButtonLink class="SignUpButton" Href="/sign-up">Sign Up</MatButtonLink>
 
+@code {
+    private string? currentUrl;
+
+    protected override void OnInitialized()
+    {
+        currentUrl = Navigation.Uri;
+        Navigation.LocationChanged += OnLocationChanged;
+    }
+
+    private void OnLocationChanged(object? sender, LocationChangedEventArgs e)
+    {
+        currentUrl = Navigation.Uri;
+        StateHasChanged();
+    }
+
+    public void Dispose() => Navigation.LocationChanged -= OnLocationChanged;
+}
 
             
 

--- a/Annotations.Blazor/Components/RedirectToLogin.razor
+++ b/Annotations.Blazor/Components/RedirectToLogin.razor
@@ -1,0 +1,8 @@
+﻿@inject NavigationManager Navigation
+
+@code {
+    protected override void OnInitialized()
+    {
+        Navigation.NavigateTo($"authentication/login?returnUrl={Uri.EscapeDataString(Navigation.Uri)}", forceLoad: true);
+    }
+}

--- a/Annotations.Blazor/Components/Routes.razor
+++ b/Annotations.Blazor/Components/Routes.razor
@@ -1,6 +1,10 @@
-﻿<Router AppAssembly="@typeof(Program).Assembly">
+﻿<Router AppAssembly="typeof(Program).Assembly">
     <Found Context="routeData">
-        <RouteView RouteData="routeData" DefaultLayout="typeof(Layout.MainLayout)" />
+        <AuthorizeRouteView RouteData="routeData" DefaultLayout="typeof(Layout.MainLayout)">
+            <NotAuthorized>
+                <RedirectToLogin />
+            </NotAuthorized>
+        </AuthorizeRouteView>
         <FocusOnNavigate RouteData="routeData" Selector="h1" />
     </Found>
 </Router>

--- a/Annotations.Blazor/Components/_Imports.razor
+++ b/Annotations.Blazor/Components/_Imports.razor
@@ -6,5 +6,5 @@
 @using static Microsoft.AspNetCore.Components.Web.RenderMode
 @using Microsoft.AspNetCore.Components.Web.Virtualization
 @using Microsoft.JSInterop
-
+@using Microsoft.AspNetCore.Components.Authorization
 @using MatBlazor

--- a/Annotations.Blazor/CookieOidcRefresher.cs
+++ b/Annotations.Blazor/CookieOidcRefresher.cs
@@ -1,0 +1,107 @@
+﻿/*
+ * Sourced from: https://github.com/dotnet/blazor-samples/tree/main/8.0/BlazorWebAppOidcServer
+ * Provided by Microsoft Corporation under the MIT license.
+*/
+
+using System.Globalization;
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.AspNetCore.Authentication.OpenIdConnect;
+using Microsoft.Extensions.Options;
+using Microsoft.IdentityModel.JsonWebTokens;
+using Microsoft.IdentityModel.Protocols.OpenIdConnect;
+using Microsoft.IdentityModel.Tokens;
+
+namespace Annotations.Blazor;
+
+// https://github.com/dotnet/aspnetcore/issues/8175
+internal sealed class CookieOidcRefresher(IOptionsMonitor<OpenIdConnectOptions> oidcOptionsMonitor)
+{
+    private readonly OpenIdConnectProtocolValidator oidcTokenValidator = new()
+    {
+        // We no longer have the original nonce cookie which is deleted at the end of the authorization code flow having served its purpose.
+        // Even if we had the nonce, it's likely expired. It's not intended for refresh requests. Otherwise, we'd use oidcOptions.ProtocolValidator.
+        RequireNonce = false,
+    };
+
+    public async Task ValidateOrRefreshCookieAsync(CookieValidatePrincipalContext validateContext, string oidcScheme)
+    {
+        var accessTokenExpirationText = validateContext.Properties.GetTokenValue("expires_at");
+        if (!DateTimeOffset.TryParse(accessTokenExpirationText, out var accessTokenExpiration))
+        {
+            return;
+        }
+
+        var oidcOptions = oidcOptionsMonitor.Get(oidcScheme);
+        var now = oidcOptions.TimeProvider!.GetUtcNow();
+        if (now + TimeSpan.FromMinutes(5) < accessTokenExpiration)
+        {
+            return;
+        }
+
+        var oidcConfiguration = await oidcOptions.ConfigurationManager!.GetConfigurationAsync(validateContext.HttpContext.RequestAborted);
+        var tokenEndpoint = oidcConfiguration.TokenEndpoint ?? throw new InvalidOperationException("Cannot refresh cookie. TokenEndpoint missing!");
+
+        using var refreshResponse = await oidcOptions.Backchannel.PostAsync(tokenEndpoint,
+            new FormUrlEncodedContent(new Dictionary<string, string?>()
+            {
+                ["grant_type"] = "refresh_token",
+                ["client_id"] = oidcOptions.ClientId,
+                ["client_secret"] = oidcOptions.ClientSecret,
+                ["scope"] = string.Join(" ", oidcOptions.Scope),
+                ["refresh_token"] = validateContext.Properties.GetTokenValue("refresh_token"),
+            }));
+
+        if (!refreshResponse.IsSuccessStatusCode)
+        {
+            validateContext.RejectPrincipal();
+            return;
+        }
+
+        var refreshJson = await refreshResponse.Content.ReadAsStringAsync();
+        var message = new OpenIdConnectMessage(refreshJson);
+
+        var validationParameters = oidcOptions.TokenValidationParameters.Clone();
+        if (oidcOptions.ConfigurationManager is BaseConfigurationManager baseConfigurationManager)
+        {
+            validationParameters.ConfigurationManager = baseConfigurationManager;
+        }
+        else
+        {
+            validationParameters.ValidIssuer = oidcConfiguration.Issuer;
+            validationParameters.IssuerSigningKeys = oidcConfiguration.SigningKeys;
+        }
+
+        var validationResult = await oidcOptions.TokenHandler.ValidateTokenAsync(message.IdToken, validationParameters);
+
+        if (!validationResult.IsValid)
+        {
+            validateContext.RejectPrincipal();
+            return;
+        }
+
+        var validatedIdToken = JwtSecurityTokenConverter.Convert(validationResult.SecurityToken as JsonWebToken);
+        validatedIdToken.Payload["nonce"] = null;
+        oidcTokenValidator.ValidateTokenResponse(new()
+        {
+            ProtocolMessage = message,
+            ClientId = oidcOptions.ClientId,
+            ValidatedIdToken = validatedIdToken,
+        });
+
+        validateContext.ShouldRenew = true;
+        validateContext.ReplacePrincipal(new ClaimsPrincipal(validationResult.ClaimsIdentity));
+
+        var expiresIn = int.Parse(message.ExpiresIn, NumberStyles.Integer, CultureInfo.InvariantCulture);
+        var expiresAt = now + TimeSpan.FromSeconds(expiresIn);
+        validateContext.Properties.StoreTokens([
+            new() { Name = "access_token", Value = message.AccessToken },
+            new() { Name = "id_token", Value = message.IdToken },
+            new() { Name = "refresh_token", Value = message.RefreshToken },
+            new() { Name = "token_type", Value = message.TokenType },
+            new() { Name = "expires_at", Value = expiresAt.ToString("o", CultureInfo.InvariantCulture) },
+        ]);
+    }
+}

--- a/Annotations.Blazor/CookieOidcServiceCollectionExtensions.cs
+++ b/Annotations.Blazor/CookieOidcServiceCollectionExtensions.cs
@@ -1,0 +1,31 @@
+﻿/*
+ * Sourced from: https://github.com/dotnet/blazor-samples/tree/main/8.0/BlazorWebAppOidcServer
+ * Provided by Microsoft Corporation under the MIT license.
+*/
+
+using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.AspNetCore.Authentication.OpenIdConnect;
+using Microsoft.IdentityModel.Protocols.OpenIdConnect;
+using Annotations.Blazor;
+
+namespace Microsoft.Extensions.DependencyInjection;
+
+internal static partial class CookieOidcServiceCollectionExtensions
+{
+    public static IServiceCollection ConfigureCookieOidcRefresh(this IServiceCollection services, string cookieScheme, string oidcScheme)
+    {
+        services.AddSingleton<CookieOidcRefresher>();
+        services.AddOptions<CookieAuthenticationOptions>(cookieScheme).Configure<CookieOidcRefresher>((cookieOptions, refresher) =>
+        {
+            cookieOptions.Events.OnValidatePrincipal = context => refresher.ValidateOrRefreshCookieAsync(context, oidcScheme);
+        });
+        services.AddOptions<OpenIdConnectOptions>(oidcScheme).Configure(oidcOptions =>
+        {
+            // Request a refresh_token.
+            oidcOptions.Scope.Add(OpenIdConnectScope.OfflineAccess);
+            // Store the refresh_token.
+            oidcOptions.SaveTokens = true;
+        });
+        return services;
+    }
+}

--- a/Annotations.Blazor/LoginLogoutEndpointRouteBuilderExtensions.cs
+++ b/Annotations.Blazor/LoginLogoutEndpointRouteBuilderExtensions.cs
@@ -22,7 +22,7 @@ internal static class LoginLogoutEndpointRouteBuilderExtensions
         // the user will automatically be signed back in the next time they visit a page that requires authentication
         // without being able to choose another account.
         group.MapPost("/logout", ([FromForm] string? returnUrl) => TypedResults.SignOut(GetAuthProperties(returnUrl),
-            [CookieAuthenticationDefaults.AuthenticationScheme, "MicrosoftOidc"]));
+            [CookieAuthenticationDefaults.AuthenticationScheme, "Annotations OIDC"]));
 
         return group;
     }

--- a/Annotations.Blazor/LoginLogoutEndpointRouteBuilderExtensions.cs
+++ b/Annotations.Blazor/LoginLogoutEndpointRouteBuilderExtensions.cs
@@ -1,0 +1,50 @@
+﻿/*
+ * Sourced from: https://github.com/dotnet/blazor-samples/tree/main/8.0/BlazorWebAppOidcServer
+ * Provided by Microsoft Corporation under the MIT license.
+*/
+
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Microsoft.AspNetCore.Routing;
+
+internal static class LoginLogoutEndpointRouteBuilderExtensions
+{
+    internal static IEndpointConventionBuilder MapLoginAndLogout(this IEndpointRouteBuilder endpoints)
+    {
+        var group = endpoints.MapGroup("");
+
+        group.MapGet("/login", (string? returnUrl) => TypedResults.Challenge(GetAuthProperties(returnUrl)))
+            .AllowAnonymous();
+
+        // Sign out of the Cookie and OIDC handlers. If you do not sign out with the OIDC handler,
+        // the user will automatically be signed back in the next time they visit a page that requires authentication
+        // without being able to choose another account.
+        group.MapPost("/logout", ([FromForm] string? returnUrl) => TypedResults.SignOut(GetAuthProperties(returnUrl),
+            [CookieAuthenticationDefaults.AuthenticationScheme, "MicrosoftOidc"]));
+
+        return group;
+    }
+
+    private static AuthenticationProperties GetAuthProperties(string? returnUrl)
+    {
+        const string pathBase = "/";
+
+        // Prevent open redirects.
+        if (string.IsNullOrEmpty(returnUrl))
+        {
+            returnUrl = pathBase;
+        }
+        else if (!Uri.IsWellFormedUriString(returnUrl, UriKind.Relative))
+        {
+            returnUrl = new Uri(returnUrl, UriKind.Absolute).PathAndQuery;
+        }
+        else if (returnUrl[0] != '/')
+        {
+            returnUrl = $"{pathBase}{returnUrl}";
+        }
+
+        return new AuthenticationProperties { RedirectUri = returnUrl };
+    }
+}

--- a/Annotations.Blazor/Program.cs
+++ b/Annotations.Blazor/Program.cs
@@ -92,7 +92,7 @@ builder.Services.AddAuthentication(oidcScheme)
         oidcOptions.TokenValidationParameters.NameClaimType = JwtRegisteredClaimNames.Name;
         oidcOptions.TokenValidationParameters.RoleClaimType = "role";
 
-        ICollection<string> scopes = ["email", "roles"];
+        ICollection<string> scopes = ["email", "roles", "profile"];
         foreach (string scope in scopes) oidcOptions.Scope.Add(scope);
 
         /* Many OIDC providers work with the default issuer validator, but the

--- a/Annotations.Blazor/Program.cs
+++ b/Annotations.Blazor/Program.cs
@@ -92,7 +92,7 @@ builder.Services.AddAuthentication(oidcScheme)
         oidcOptions.TokenValidationParameters.NameClaimType = JwtRegisteredClaimNames.Name;
         oidcOptions.TokenValidationParameters.RoleClaimType = "role";
 
-        ICollection<string> scopes = ["email", "roles", "profile"];
+        ICollection<string> scopes = ["email", "roles", "profile", "api"];
         foreach (string scope in scopes) oidcOptions.Scope.Add(scope);
 
         /* Many OIDC providers work with the default issuer validator, but the
@@ -132,6 +132,7 @@ builder.Services.AddCascadingAuthenticationState();
 builder.Services.AddRazorComponents()
     .AddInteractiveServerComponents();
 
+builder.Services.AddHttpContextAccessor();
 builder.Services.AddHttpClient();
 
 var app = builder.Build();

--- a/Annotations.Blazor/Program.cs
+++ b/Annotations.Blazor/Program.cs
@@ -1,10 +1,138 @@
+/*
+ * The following code is based on https://github.com/dotnet/blazor-samples and https://github.com/dotnet/blazor-samples/tree/main/8.0/BlazorWebAppOidcServer
+ * Provided by Microsoft Corporation under the MIT license.
+ */
+
 using Annotations.Blazor.Components;
+using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.IdentityModel.JsonWebTokens;
+using Microsoft.IdentityModel.Protocols.OpenIdConnect;
+
+const string oidcScheme = "Annotations OIDC";
 
 var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddAuthentication(oidcScheme)
+    .AddOpenIdConnect(oidcScheme, oidcOptions =>
+    {
+        /* For the following OIDC settings, any line that's commented out
+         * represents a DEFAULT setting. If you adopt the default, you can
+         * remove the line if you wish.
+         *
+         * ........................................................................
+         * The OIDC handler must use a sign-in scheme capable of persisting 
+         * user credentials across requests.
+         */
+
+        oidcOptions.SignInScheme = CookieAuthenticationDefaults.AuthenticationScheme;
+        
+        /* The "openid" and "profile" scopes are required for the OIDC handler 
+         * and included by default. You should enable these scopes here if scopes 
+         * are provided by "Authentication:Schemes:MicrosoftOidc:Scope" 
+         * configuration because configuration may overwrite the scopes collection.
+         */
+
+        //oidcOptions.Scope.Add(OpenIdConnectScope.OpenIdProfile);
+
+        /* The following paths must match the redirect and post logout redirect 
+         * paths configured when registering the application with the OIDC provider. 
+         * The default values are "/signin-oidc" and "/signout-callback-oidc".
+         */
+
+        oidcOptions.CallbackPath = new PathString("/signin-oidc");
+        oidcOptions.SignedOutCallbackPath = new PathString("/signout-callback-oidc");
+        
+        /* The RemoteSignOutPath is the "Front-channel logout URL" for remote single 
+         * sign-out. The default value is "/signout-oidc".
+         */
+
+        //oidcOptions.RemoteSignOutPath = new PathString("/signout-oidc");
+
+        /* The authority is the server to contact for oidc authentication.
+         * Here it is set to a localhost port. IRL it would refer to the website 
+         * of the OpenID Connect authority.
+         */
+        
+        oidcOptions.Authority = builder.Configuration["OidcAuthority"] ?? throw new InvalidOperationException("OIDC Authority not found");
+        
+        /* The authority will recognise this application by the client ID. 
+         * The client ID is not a secret, but it is not helpful to publish to
+         * third parties. 
+         * For a confidential authentication process, the application and the
+         * authority will also keep a client secret. This indeed a secret and
+         * must be treated as such. 
+         * A client secret is only viable in cases where the server handles
+         * authentication on behalf of the user. In cases where the client
+         * application at the user contacts the authority itself, this scheme
+         * cannot be used. 
+         * To repeat, mobile/native apps and single page apps cannot use auth
+         * involving a client secret!
+         */
+
+        oidcOptions.ClientId = builder.Configuration["authentication:oidc:clientid"] ?? throw new InvalidOperationException("Missing authentication:oidc:clientid");
+        oidcOptions.ClientSecret = builder.Configuration["authentication:oidc:clientsecret"] ?? throw new InvalidOperationException("Missing authentication:oidc:clientsecret");
+
+        /* Setting ResponseType to "code" configures the OIDC handler to use 
+         * authorization code flow. Implicit grants and hybrid flows are unnecessary
+         * in this mode. In a Microsoft Entra ID app registration, you don't need to 
+         * select either box for the authorization endpoint to return access tokens 
+         * or ID tokens. The OIDC handler automatically requests the appropriate 
+         * tokens using the code returned from the authorization endpoint.
+         */
+
+        oidcOptions.ResponseType = OpenIdConnectResponseType.Code;
+        
+        /* Set MapInboundClaims to "false" to obtain the original claim types from 
+         * the token. Many OIDC servers use "name" and "role"/"roles" rather than 
+         * the SOAP/WS-Fed defaults in ClaimTypes. Adjust these values if your 
+         * identity provider uses different claim types.
+         */
+
+        oidcOptions.MapInboundClaims = false;
+        oidcOptions.TokenValidationParameters.NameClaimType = JwtRegisteredClaimNames.Name;
+        oidcOptions.TokenValidationParameters.RoleClaimType = "role";
+
+        ICollection<string> scopes = ["email", "roles"];
+        foreach (string scope in scopes) oidcOptions.Scope.Add(scope);
+
+        /* Many OIDC providers work with the default issuer validator, but the
+         * configuration must account for the issuer parameterized with "{TENANT ID}" 
+         * returned by the "common" endpoint's /.well-known/openid-configuration
+         * For more information, see
+         * https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/issues/1731
+         */
+
+        //var microsoftIssuerValidator = AadIssuerValidator.GetAadIssuerValidator(oidcOptions.Authority);
+        //oidcOptions.TokenValidationParameters.IssuerValidator = microsoftIssuerValidator.Validate;
+
+        /* OIDC connect options set later via ConfigureCookieOidcRefresh
+         *
+         * (1) The "offline_access" scope is required for the refresh token.
+         *
+         * (2) SaveTokens is set to true, which saves the access and refresh tokens
+         * in the cookie, so the app can authenticate requests for weather data and
+         * use the refresh token to obtain a new access token on access token
+         * expiration.
+         */
+    })
+    .AddCookie(CookieAuthenticationDefaults.AuthenticationScheme);
+
+/* ConfigureCookieOidcRefresh attaches a cookie OnValidatePrincipal callback to get
+ * a new access token when the current one expires, and reissue a cookie with the
+ * new access token saved inside. If the refresh fails, the user will be signed
+ * out. OIDC connect options are set for saving tokens and the offline access
+ * scope.
+ */
+builder.Services.ConfigureCookieOidcRefresh(CookieAuthenticationDefaults.AuthenticationScheme, oidcScheme);
+
+builder.Services.AddAuthorization();
+builder.Services.AddCascadingAuthenticationState();
 
 // Add services to the container.
 builder.Services.AddRazorComponents()
     .AddInteractiveServerComponents();
+
+builder.Services.AddHttpClient();
 
 var app = builder.Build();
 
@@ -23,5 +151,7 @@ app.UseAntiforgery();
 
 app.MapRazorComponents<App>()
     .AddInteractiveServerRenderMode();
+
+app.MapGroup("/authentication").MapLoginAndLogout();
 
 app.Run();

--- a/Annotations.Blazor/Properties/launchSettings.json
+++ b/Annotations.Blazor/Properties/launchSettings.json
@@ -9,20 +9,20 @@
       }
     },
     "profiles": {
-      "http": {
-        "commandName": "Project",
-        "dotnetRunMessages": true,
-        "launchBrowser": true,
-        "applicationUrl": "http://localhost:5254",
-        "environmentVariables": {
-          "ASPNETCORE_ENVIRONMENT": "Development"
-        }
-      },
       "https": {
         "commandName": "Project",
         "dotnetRunMessages": true,
         "launchBrowser": true,
         "applicationUrl": "https://localhost:7238;http://localhost:5254",
+        "environmentVariables": {
+          "ASPNETCORE_ENVIRONMENT": "Development"
+        }
+      },
+	  "http": {
+        "commandName": "Project",
+        "dotnetRunMessages": true,
+        "launchBrowser": true,
+        "applicationUrl": "http://localhost:5254",
         "environmentVariables": {
           "ASPNETCORE_ENVIRONMENT": "Development"
         }

--- a/Annotations.Blazor/appsettings.json
+++ b/Annotations.Blazor/appsettings.json
@@ -5,5 +5,6 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "OidcAuthority": "https://localhost:5001/"
 }


### PR DESCRIPTION
This PR contains added place for user-secrets and HTTPS security instead of HTTP.
Then auth handling has been added to the front-end.
In the front-end domain, we packed the sign-in buttons in authorization control, so it handles view for enduser.
Lastly we have made a test endpoint that shows the access flow to the API. See endpoint location:
https://localhost:7238/apiaccess