### PR TITLE
Possible to debug API using locally created tokens

### DIFF
--- a/Annotations.API/Groups/ImagesGroup.cs
+++ b/Annotations.API/Groups/ImagesGroup.cs
@@ -90,8 +90,7 @@ public static class ImagesGroup
                 return Results.StatusCode(200);
             }
 
-
-        });
+        }).DisableAntiforgery();
         //ellers ved billedfil brug da
         pathBuilder.MapGet("/{imageId}", async ([FromRoute] string imageId, [FromServices] IAzureClientFactory<BlobServiceClient> clientFactory) =>
         {

--- a/Annotations.API/Program.cs
+++ b/Annotations.API/Program.cs
@@ -6,8 +6,6 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Azure;
-using Microsoft.Extensions.Options;
-using Microsoft.IdentityModel.Tokens;
 using Microsoft.Net.Http.Headers;
 using Microsoft.OpenApi.Models;
 
@@ -74,8 +72,6 @@ builder.Services.AddAuthorization(options =>
     options.DefaultPolicy = defaultAuthorizationPolicyBuilder.Build();
 });
 
-builder.Services.AddAntiforgery();
-
 builder.Services.AddAzureClients(clientBuilder =>
 {
     clientBuilder.AddBlobServiceClient(builder.Configuration["AzureStorageConnection"]!);
@@ -104,7 +100,6 @@ app.UseStaticFiles();
 app.UseRouting();
 app.UseAuthorization();
 app.UseHttpsRedirection();
-app.UseAntiforgery();
 
 app.Run();
 

--- a/Annotations.API/Program.cs
+++ b/Annotations.API/Program.cs
@@ -57,8 +57,8 @@ builder.Services.AddAuthentication("AnnotationsBearer")
     .AddJwtBearer()
     .AddJwtBearer("AnnotationsBearer", jwtOptions =>
     {
-        jwtOptions.Authority = builder.Configuration["jwt:Authority"] ?? throw new InvalidOperationException("JWT Authority not found");
-        jwtOptions.Audience = builder.Configuration["jwt:Audience"] ?? throw new InvalidOperationException("JWT Audience not found");
+        jwtOptions.Authority = builder.Configuration["authentication:jwt:authority"] ?? throw new InvalidOperationException("JWT Authority not found");
+        jwtOptions.Audience = builder.Configuration["authentication:jwt:audience"] ?? throw new InvalidOperationException("JWT Audience not found");
     });
 
 // https://learn.microsoft.com/en-us/aspnet/core/security/authorization/limitingidentitybyscheme?view=aspnetcore-8.0

--- a/Annotations.API/appsettings.Development.json
+++ b/Annotations.API/appsettings.Development.json
@@ -4,5 +4,18 @@
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning"
     }
+  },
+  "Authentication": {
+    "Schemes": {
+      "Bearer": {
+        "ValidAudiences": [
+          "http://localhost:24450",
+          "https://localhost:44389",
+          "https://localhost:7250",
+          "http://localhost:5084"
+        ],
+        "ValidIssuer": "dotnet-user-jwts"
+      }
+    }
   }
 }

--- a/Annotations.API/appsettings.json
+++ b/Annotations.API/appsettings.json
@@ -10,7 +10,7 @@
   },
   "AllowedHosts": "*",
   "jwt": {
-    "Audience": "https://localhost:7250/",
+    "Audience": "https://localhost:7250",
     "Authority": "https://annotationscms-gzerawejb6eeh3cu.northeurope-01.azurewebsites.net/"
   }
 }

--- a/Annotations.Blazor/Components/Pages/ApiAccess.razor
+++ b/Annotations.Blazor/Components/Pages/ApiAccess.razor
@@ -42,6 +42,7 @@ else
 
         using var response = await client.SendAsync(requestMessage);
 
+        
         try
         {
             story = await response.Content.ReadFromJsonAsync<string[]>();
@@ -49,9 +50,10 @@ else
         catch (Exception e)
         {
             Console.WriteLine("Status code: " + response.StatusCode);
-            Console.WriteLine("Bearer " + accessToken);
-            throw e;
+            story = new string[1];
+            story[0] = response.StatusCode.ToString();
         }
+        
 
     }
 

--- a/Annotations.Blazor/Components/Pages/ApiAccess.razor
+++ b/Annotations.Blazor/Components/Pages/ApiAccess.razor
@@ -41,7 +41,18 @@ else
         requestMessage.Headers.Authorization = new("Bearer", accessToken);
 
         using var response = await client.SendAsync(requestMessage);
-        story = await response.Content.ReadFromJsonAsync<string[]>();
+
+        try
+        {
+            story = await response.Content.ReadFromJsonAsync<string[]>();
+        }
+        catch (Exception e)
+        {
+            Console.WriteLine("Status code: " + response.StatusCode);
+            Console.WriteLine("Bearer " + accessToken);
+            throw e;
+        }
+
     }
 
 }

--- a/Annotations.Blazor/Program.cs
+++ b/Annotations.Blazor/Program.cs
@@ -54,7 +54,7 @@ builder.Services.AddAuthentication(oidcScheme)
          * of the OpenID Connect authority.
          */
         
-        oidcOptions.Authority = builder.Configuration["OidcAuthority"] ?? throw new InvalidOperationException("OIDC Authority not found");
+        oidcOptions.Authority = builder.Configuration["authentication:oidc:authority"] ?? throw new InvalidOperationException("Missing authentication:oidc:authority");
         
         /* The authority will recognise this application by the client ID. 
          * The client ID is not a secret, but it is not helpful to publish to

--- a/Annotations.Blazor/appsettings.json
+++ b/Annotations.Blazor/appsettings.json
@@ -5,6 +5,5 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "AllowedHosts": "*",
-  "OidcAuthority": "https://annotationscms-gzerawejb6eeh3cu.northeurope-01.azurewebsites.net/"
+  "AllowedHosts": "*"
 }


### PR DESCRIPTION
Here we address issues previously experienced when designing API endpoints. 

- Make it possible to debug endpoints locally. 
  - Obtain authentication using `dotnet user-jwts create` on the API project to do so. 
  - This sets up user-secrets to recognise self-made tokens, and returns a basic JWT for use with Swagger UI, etc. 
- We have ensured that the API accepts bearer tokens from our self-hosted online user base. 
- We have once and for all confirmed how to access the API with Blazor server as a proxy. 