### PR TITLE
Pagination for /images/dataets

### DIFF
--- a/Annotations.API/Groups/ImagesGroup.cs
+++ b/Annotations.API/Groups/ImagesGroup.cs
@@ -235,15 +235,16 @@ public static class ImagesGroup
                         ReviewedBy = u.ReviewedBy
                     })
                     .ToListAsync();
-                int[] names = new int[datasets.Count];
-                int counter = 0;
+                DatasetModel[] datasetsarray = datasets.ToArray();
+                //int[] names = new int[datasets.Count];
+                /*int counter = 0;
                 foreach (DatasetModel dataset in datasets)//better way of doing this
                 {
                     names[counter] = dataset.Id;
                     counter++;
-                }
-                return names;//array of all ids of datasets
-
+                }*/
+                //return names;//array of all ids of datasets
+                return datasetsarray;
 
             }).DisableAntiforgery();
         

--- a/Annotations.API/Groups/ImagesGroup.cs
+++ b/Annotations.API/Groups/ImagesGroup.cs
@@ -235,11 +235,11 @@ public static class ImagesGroup
                         ReviewedBy = u.ReviewedBy
                     })
                     .ToListAsync();
-                int[] names = new int[datasets.Count];
+                DatasetModel[] names = new DatasetModel[datasets.Count];
                 int counter = 0;
                 foreach (DatasetModel dataset in datasets)//better way of doing this
                 {
-                    names[counter] = dataset.Id;
+                    names[counter] = dataset;
                     counter++;
                 }
 

--- a/Annotations.API/Groups/ImagesGroup.cs
+++ b/Annotations.API/Groups/ImagesGroup.cs
@@ -235,14 +235,13 @@ public static class ImagesGroup
                         ReviewedBy = u.ReviewedBy
                     })
                     .ToListAsync();
-                DatasetModel[] names = new DatasetModel[datasets.Count];
+                int[] names = new int[datasets.Count];
                 int counter = 0;
                 foreach (DatasetModel dataset in datasets)//better way of doing this
                 {
-                    names[counter] = dataset;
+                    names[counter] = dataset.Id;
                     counter++;
                 }
-
                 return names;//array of all ids of datasets
 
 

--- a/Annotations.Blazor/Components/Pages/Images/ImagesDatasetImages.razor
+++ b/Annotations.Blazor/Components/Pages/Images/ImagesDatasetImages.razor
@@ -1,4 +1,4 @@
-﻿@page "/images/datasets/{dataset}"
+﻿@page "/images/datasets/{dataset}/{pagenumber}"
 @using MatBlazor
 @using Microsoft.AspNetCore.Authentication
 @using global::Annotations.Core.Models

--- a/Annotations.Blazor/Components/Pages/Images/ImagesDatasetsReal.razor
+++ b/Annotations.Blazor/Components/Pages/Images/ImagesDatasetsReal.razor
@@ -87,7 +87,7 @@
                 <MatButtonLink href="@($"https://localhost:7238/images/datasets/{context.Id}")">Dataset: @context.Id</MatButtonLink>
             </td>
             <td>
-                Images in Dataset: ?
+                Images in Dataset: ? <!-- TBD how to display all images in Dataset --->
             </td>
             <td>
                 Category: @context.Category
@@ -191,14 +191,14 @@
  
         public int ReviewedBy { get; set; }
         
-        public Dataset(int id, List<int> ImageIds, string Category, int AnnotatedBy, int ReviewedBy)
+        public Dataset(int id, List<int> imageIds, string category, int annotatedBy, int reviewedBy)
         
         {
             Id = id;
-            ImageIds = ImageIds;
-            Category = Category;
-            AnnotatedBy = AnnotatedBy;
-            ReviewedBy = ReviewedBy;
+            ImageIds = imageIds;
+            Category = category;
+            AnnotatedBy = annotatedBy;
+            ReviewedBy = reviewedBy;
         }
     }
 

--- a/Annotations.Blazor/Components/Pages/Images/ImagesDatasetsReal.razor
+++ b/Annotations.Blazor/Components/Pages/Images/ImagesDatasetsReal.razor
@@ -1,8 +1,8 @@
-﻿@page "/images/datasets"
+﻿@page "/images/datasets/page={PageNumber:int}"
 @using Microsoft.AspNetCore.Authentication
-
 @inject IHttpClientFactory ClientFactory
 @inject IHttpContextAccessor httpContextAccessor
+@inject NavigationManager NavigationManager
 <style>
     .container {
         display: flex;
@@ -54,18 +54,15 @@
         margin: 0; 
         width: 21%
     }
-
 </style>
 <div style=" display: flex; flex-direction:row;">
-
     <span style="margin-left:13%; margin-top:0.0001%; padding-bottom:2%; font-weight: bold; width: 72%; font-size: 215%">Manage datasets</span>
     <div style="width:15%">
         <button class="orderingButton">Order by...</button>
     </div>
-
 </div>
 <div class = "container DivToScroll">
-    @foreach (var name in datasets)//TODO: dont hardcode these values (e.g. number of images)
+    @foreach (var name in datasetslist)//TODO: dont hardcode these values (e.g. number of images)
     {
         <div class="datasetContainers">
             <div style=" display: flex; flex-direction:row; flex-wrap: nowrap">
@@ -83,36 +80,37 @@
             </div>
         </div>
     }
+    <MatButton OnClick="@PageNumberNext">Next page</MatButton>
+    @if (PageNumber > 1) {
+    <MatButton OnClick="@PageNumberPrev">Previous page</MatButton>
+    }
 </div>
 
 
 
 
-
 @code{
-    public List<int>? datasets = new List<int>();//it only works as a list, not an array
+    [Parameter] public int PageNumber {get; set;} = 1;
+    
+    public List<int>? datasetslist = new List<int>();//it only works as a list, not an array
     private bool error = false;//this isn't used yet
     //TODO: error handling (what blazor pages returns)
 
     protected override async Task OnInitializedAsync()
     {
         var httpContext = httpContextAccessor.HttpContext ?? throw new InvalidOperationException("No HttpContext available");//make connection
-
         var accessToken = await httpContext.GetTokenAsync("access_token") ?? throw new InvalidOperationException("No access_token was saved");//authorization
-
         var client = ClientFactory.CreateClient();
         client.BaseAddress = new("https://localhost:7250");//connect to Web API
-
-        using var requestMessage = new HttpRequestMessage(HttpMethod.Get, $"/images/datasets");//access endpoint
+        using var requestMessage = new HttpRequestMessage(HttpMethod.Get, $"/images/datasets/");//access endpoint
         requestMessage.Headers.Authorization = new("Bearer", accessToken);//bearer token for authorization
-
         using var response = await client.SendAsync(requestMessage);//sending the response
         try
         {
             var existingIds = await response.Content.ReadFromJsonAsync<int[]>();//int array of all the ids of all the existing datasets
             for (int i = 0; i < existingIds.Length; i++)
             {
-                datasets.Add(existingIds[i]);
+                datasetslist.Add(existingIds[i]);
             }
         }
         catch (Exception e)
@@ -120,7 +118,25 @@
             Console.WriteLine("Status code: " + response.StatusCode);
             error = true;
         }
-
     }
 
+    public int IncreasePageNumber ()
+    {
+        return PageNumber++;
+    }
+    
+    public int DecreasePageNumber ()
+    {
+        return PageNumber--;
+    }
+
+    public void PageNumberNext (MouseEventArgs e) {
+        //public int NewPage = IncreasePageNumber();
+        //needs logic for changing pagenumber
+    }
+
+    public void PageNumberPrev (MouseEventArgs e) {
+        //public int NewPage = DecreasePageNumber();
+        //needs logic for changing pagenumber
+    }
 }

--- a/Annotations.Blazor/Components/Pages/Images/ImagesDatasetsReal.razor
+++ b/Annotations.Blazor/Components/Pages/Images/ImagesDatasetsReal.razor
@@ -18,24 +18,21 @@
     }
 
     .table-formatting {
+        display: block; /* Required for margin: auto to work */
         position: relative;
         border-collapse: collapse;
         border-spacing: 0;
         overflow-x: auto;
-        margin-left: 10%;
-        margin-right: 10%;
-        width: 80%;
+        margin: 1% auto; /* Centers horizontally + keeps vertical margin */
+        width: 41.5%;
         background-color: #e3e7ee;
-        padding-top: 0.8%;
-        padding-bottom: 0.3%;
-        padding-left: 1%;
-        margin-bottom: 1%;
-        margin-top: 1%;
-        border-radius: 10px 10px 10px 10px;
+        padding: 0.8% 1% 0.3% 1%; /* Shorthand for top, right, bottom, left */
+        border-radius: 10px;
         text-align: center;
     }
 
     .table-formatting th {
+        text-align: center;
         padding:0;
         margin: 2%; 
         width: 22.5%;
@@ -54,6 +51,81 @@
         background: #e3e7ee;
     }
 
+    /* Target the first column (ID column) */
+    .table-formatting tr > td:nth-child(1) {
+        width: 100px; /* or whatever width you want */
+        max-width: 100px;
+        min-width: 100px;
+        /* Add any other styles you want for this column */
+    }
+
+    /* If you need to target the header as well */
+    .table-formatting th:nth-child(1){
+        width: 100px;
+        max-width: 100px;
+        min-width: 100px;
+    }
+
+    /* Target the first column (ID column) */
+    .table-formatting tr > td:nth-child(2) {
+        width: 100px; /* or whatever width you want */
+        max-width: 100px;
+        min-width: 100px;
+        /* Add any other styles you want for this column */
+    }
+
+    /* If you need to target the header as well */
+    .table-formatting th:nth-child(2) {
+        width: 100px;
+        max-width: 100px;
+        min-width: 100px;
+    }
+
+    /* Target the first column (ID column) */
+    .table-formatting tr > td:nth-child(3) {
+        width: 150px; /* or whatever width you want */
+        max-width: 150px;
+        min-width: 150px;
+        /* Add any other styles you want for this column */
+    }
+
+    /* If you need to target the header as well */
+    .table-formatting th:nth-child(3) {
+        width: 150px;
+        max-width: 150px;
+        min-width: 150px;
+    }
+
+    /* Target the first column (ID column) */
+    .table-formatting tr > td:nth-child(4) {
+        width: 100px; /* or whatever width you want */
+        max-width: 100px;
+        min-width: 100px;
+        /* Add any other styles you want for this column */
+    }
+
+    /* If you need to target the header as well */
+    .table-formatting th:nth-child(4) {
+        width: 100px;
+        max-width: 100px;
+        min-width: 100px;
+    }
+
+    /* Target the first column (ID column) */
+    .table-formatting tr > td:nth-child(5) {
+        width: 100px; /* or whatever width you want */
+        max-width: 100px;
+        min-width: 100px;
+        /* Add any other styles you want for this column */
+    }
+
+    /* If you need to target the header as well */
+    .table-formatting th:nth-child(5) {
+        width: 100px;
+        max-width: 100px;
+        min-width: 100px;
+    }
+
 </style>
 
 <div style=" display: flex; flex-direction:row;">
@@ -65,23 +137,29 @@
 
 <MatThemeProvider Theme="_theme">
     <MatTable Items="Datasets" class="table-formatting">
+        <MatTableHeader>
+            <th>Dataset ID</th>
+            <th>Nr. of Images</th>
+            <th>Category</th>
+            <th>Annotated By</th>
+            <th>Reviewed By</th>
+        </MatTableHeader>
         <MatTableRow>
             <td>
-                <MatButtonLink href="@($"https://localhost:7238/images/datasets/{context.Id}")">Dataset: @context.Id</MatButtonLink>
+                <MatButtonLink href="@($"https://localhost:7238/images/datasets/{context.Id}")">@context.Id</MatButtonLink>
             </td>
             <td>
-                Images in Dataset: @context.ImageIds.Count
+                @context.ImageIds.Count
             </td>
             <td>
-                Category: @context.Category
+                @context.Category
             </td>
             <td>
-                Annotated By: @context.AnnotatedBy
+                @context.AnnotatedBy
             </td>
             <td>
-                Reviewed By: @context.ReviewedBy
+                @context.ReviewedBy
             </td>
-
         </MatTableRow>
     </MatTable>
 </MatThemeProvider>
@@ -138,6 +216,7 @@
     public class Dataset
     {
         public int Id { get; set; }
+        
         public List<int> ImageIds{ get; set; }
    
         public string Category { get; set; }
@@ -147,7 +226,6 @@
         public int ReviewedBy { get; set; }
         
         public Dataset(int id, List<int> imageIds, string category, int annotatedBy, int reviewedBy)
-        
         {
             Id = id;
             ImageIds = imageIds;

--- a/Annotations.Blazor/Components/Pages/Images/ImagesDatasetsReal.razor
+++ b/Annotations.Blazor/Components/Pages/Images/ImagesDatasetsReal.razor
@@ -1,6 +1,7 @@
 ﻿@page "/images/datasets/"
 @rendermode InteractiveServer
 @using Microsoft.AspNetCore.Authentication
+@using global::Annotations.Core.Models
 @inject IHttpClientFactory ClientFactory
 @inject IHttpContextAccessor httpContextAccessor
 @inject NavigationManager NavigationManager
@@ -34,9 +35,9 @@
     }
 
     .table-formatting {
+        position: relative;
         border-collapse: collapse;
         border-spacing: 0;
-        display: inline-block;
         overflow-x: auto;
         margin-left: 10%;
         margin-right: 10%;
@@ -48,22 +49,28 @@
         margin-bottom: 1%;
         margin-top: 1%;
         border-radius: 10px 10px 10px 10px;
+        text-align: center;
     }
 
     .table-formatting th {
-        height: 0%
-        margin-top: 0%;
-        margin-bottom: 0%;
-        border: none;
-    }
+        padding:0;
+        margin: 2%; 
+        width: 22.5%;
+        height: 0%;
 
-    .table-formatting td {
-        padding: 2%;
-        margin: 0; 
-        width: 20%;
         border: none;
         background: #e3e7ee;
     }
+
+    .table-formatting td {
+        text-align: center;
+        padding:0;
+        margin: 2%; 
+
+        width: 22.5%;
+        background: #e3e7ee;
+    }
+
 </style>
 
 <div style=" display: flex; flex-direction:row;">
@@ -75,23 +82,23 @@
 
 
     <MatTable Items="Datasets" class="table-formatting">
-
         <MatTableRow>
-            <td>
+           <td>
                 <MatButtonLink href="@($"https://localhost:7238/images/datasets/{context.Id}")">Dataset: @context.Id</MatButtonLink>
             </td>
             <td>
                 Images in Dataset: ?
             </td>
             <td>
-                Category: ?
+                Category: @context.Category
             </td>
             <td>
-                Annotated By: ?
+                Annotated By: @context.AnnotatedBy
             </td>
             <td>
-                Reviewed By: ?
+                Reviewed By: @context.ReviewedBy
             </td>
+            
         </MatTableRow>
     </MatTable>
 
@@ -148,12 +155,17 @@
             using var response = await client.SendAsync(requestMessage);//sending the response
             if (response.IsSuccessStatusCode)
             {
-                var existingIds = await response.Content.ReadFromJsonAsync<int[]>();//int array of all the ids of all the existing datasets
-                foreach (var id in existingIds)
+                var datasetmodels = await response.Content.ReadFromJsonAsync<DatasetModel[]>();//int array of all the ids of all the existing datasets
+                foreach (var datasetmodel in datasetmodels)
                 {
-                    Datasets.Add(new Dataset(id));
+                    Datasets.Add(new Dataset(datasetmodel.Id,
+                    datasetmodel.ImageIds,
+                    datasetmodel.Category,
+                    datasetmodel.AnnotatedBy,
+                    datasetmodel.ReviewedBy));
                 }
             }
+
             else
             {
                 _error = true;
@@ -171,22 +183,22 @@
     public class Dataset
     {
         public int Id { get; set; }
-       /* public List<int> ImageIds{ get; set; }
+        public List<int> ImageIds{ get; set; }
    
         public string Category { get; set; }
    
         public int AnnotatedBy { get; set; }
  
         public int ReviewedBy { get; set; }
-        */
-        public Dataset(int id)
+        
+        public Dataset(int id, List<int> ImageIds, string Category, int AnnotatedBy, int ReviewedBy)
         
         {
             Id = id;
-            /*ImageIds = ImageIds;
+            ImageIds = ImageIds;
             Category = Category;
             AnnotatedBy = AnnotatedBy;
-            ReviewedBy = ReviewedBy;*/
+            ReviewedBy = ReviewedBy;
         }
     }
 

--- a/Annotations.Blazor/Components/Pages/Images/ImagesDatasetsReal.razor
+++ b/Annotations.Blazor/Components/Pages/Images/ImagesDatasetsReal.razor
@@ -50,10 +50,17 @@
         border-radius: 10px 10px 10px 10px;
     }
 
-    .table-formatting th, td {
-        padding:0;
+    .table-formatting th {
+        height: 0%
+        margin-top: 0%;
+        margin-bottom: 0%;
+        border: none;
+    }
+
+    .table-formatting td {
+        padding: 2%;
         margin: 0; 
-        width: 5%;
+        width: 20%;
         border: none;
         background: #e3e7ee;
     }
@@ -74,16 +81,16 @@
                 <MatButtonLink href="@($"https://localhost:7238/images/datasets/{context.Id}")">Dataset: @context.Id</MatButtonLink>
             </td>
             <td>
-                Images in Dataset: @context.ImageIds.Sum()
+                Images in Dataset: ?
             </td>
             <td>
-                Category: @context.Category
+                Category: ?
             </td>
             <td>
-                Annotated By: @context.AnnotatedBy
+                Annotated By: ?
             </td>
             <td>
-                Reviewed By: @context.ReviewedBy
+                Reviewed By: ?
             </td>
         </MatTableRow>
     </MatTable>
@@ -141,10 +148,10 @@
             using var response = await client.SendAsync(requestMessage);//sending the response
             if (response.IsSuccessStatusCode)
             {
-                var datasetmodels = await response.Content.ReadFromJsonAsync<int[]>();//int array of all the ids of all the existing datasets
-                foreach (var dataset in datasetmodels)
+                var existingIds = await response.Content.ReadFromJsonAsync<int[]>();//int array of all the ids of all the existing datasets
+                foreach (var id in existingIds)
                 {
-                    Datasets.Add(new Dataset(dataset));
+                    Datasets.Add(new Dataset(id));
                 }
             }
             else
@@ -164,21 +171,22 @@
     public class Dataset
     {
         public int Id { get; set; }
-        public List<int> ImageIds{ get; set; }
+       /* public List<int> ImageIds{ get; set; }
    
         public string Category { get; set; }
    
         public int AnnotatedBy { get; set; }
  
         public int ReviewedBy { get; set; }
-        
+        */
         public Dataset(int id)
+        
         {
             Id = id;
-            ImageIds = ImageIds;
+            /*ImageIds = ImageIds;
             Category = Category;
             AnnotatedBy = AnnotatedBy;
-            ReviewedBy = ReviewedBy;
+            ReviewedBy = ReviewedBy;*/
         }
     }
 

--- a/Annotations.Blazor/Components/Pages/Images/ImagesDatasetsReal.razor
+++ b/Annotations.Blazor/Components/Pages/Images/ImagesDatasetsReal.razor
@@ -23,7 +23,7 @@
         border-collapse: collapse;
         border-spacing: 0;
         overflow-x: auto;
-        margin: 1% auto; /* Centers horizontally + keeps vertical margin */
+        margin: 1% auto; /* Centers horizontally and keeps vertical margin */
         width: 41.5%;
         background-color: #e3e7ee;
         padding: 0.8% 1% 0.3% 1%; /* Shorthand for top, right, bottom, left */
@@ -51,79 +51,64 @@
         background: #e3e7ee;
     }
 
-    /* Target the first column (ID column) */
     .table-formatting tr > td:nth-child(1) {
-        width: 100px; /* or whatever width you want */
-        max-width: 100px;
-        min-width: 100px;
-        /* Add any other styles you want for this column */
+        width: 20%; 
+        max-width: 20%;
+        min-width: 20%;
     }
 
-    /* If you need to target the header as well */
     .table-formatting th:nth-child(1){
-        width: 100px;
-        max-width: 100px;
-        min-width: 100px;
+        width: 20%; 
+        max-width: 20%;
+        min-width: 20%;
     }
 
-    /* Target the first column (ID column) */
     .table-formatting tr > td:nth-child(2) {
-        width: 100px; /* or whatever width you want */
-        max-width: 100px;
-        min-width: 100px;
-        /* Add any other styles you want for this column */
+        width: 20%; 
+        max-width: 20%;
+        min-width: 20%;
     }
 
-    /* If you need to target the header as well */
     .table-formatting th:nth-child(2) {
-        width: 100px;
-        max-width: 100px;
-        min-width: 100px;
+        width: 20%; 
+        max-width: 20%;
+        min-width: 20%;
     }
 
-    /* Target the first column (ID column) */
     .table-formatting tr > td:nth-child(3) {
-        width: 150px; /* or whatever width you want */
-        max-width: 150px;
-        min-width: 150px;
-        /* Add any other styles you want for this column */
+        width: 30%; 
+        max-width: 30%;
+        min-width: 30%;
     }
 
-    /* If you need to target the header as well */
     .table-formatting th:nth-child(3) {
-        width: 150px;
-        max-width: 150px;
-        min-width: 150px;
+        width: 30%; 
+        max-width: 30%;
+        min-width: 30%;
     }
 
-    /* Target the first column (ID column) */
     .table-formatting tr > td:nth-child(4) {
-        width: 100px; /* or whatever width you want */
-        max-width: 100px;
-        min-width: 100px;
-        /* Add any other styles you want for this column */
+        width: 20%; 
+        max-width: 20%;
+        min-width: 20%;
     }
 
-    /* If you need to target the header as well */
     .table-formatting th:nth-child(4) {
-        width: 100px;
-        max-width: 100px;
-        min-width: 100px;
+        width: 20%; 
+        max-width: 20%;
+        min-width: 20%;
     }
 
-    /* Target the first column (ID column) */
     .table-formatting tr > td:nth-child(5) {
-        width: 100px; /* or whatever width you want */
-        max-width: 100px;
-        min-width: 100px;
-        /* Add any other styles you want for this column */
+        width: 20%; 
+        max-width: 20%;
+        min-width: 20%;
     }
 
-    /* If you need to target the header as well */
     .table-formatting th:nth-child(5) {
-        width: 100px;
-        max-width: 100px;
-        min-width: 100px;
+        width: 20%; 
+        max-width: 20%;
+        min-width: 20%;
     }
 
 </style>
@@ -171,7 +156,7 @@
     
     private MatTheme _theme = new MatTheme()
     {
-        Primary = MatThemeColors.Green._900.Value
+        Primary = MatThemeColors.Green._800.Value
     };
 
     protected override async Task OnInitializedAsync()

--- a/Annotations.Blazor/Components/Pages/Images/ImagesDatasetsReal.razor
+++ b/Annotations.Blazor/Components/Pages/Images/ImagesDatasetsReal.razor
@@ -80,10 +80,10 @@
     </div>
 </div>
 
-
+<MatThemeProvider Theme="_theme">
     <MatTable Items="Datasets" class="table-formatting">
         <MatTableRow>
-           <td>
+            <td>
                 <MatButtonLink href="@($"https://localhost:7238/images/datasets/{context.Id}")">Dataset: @context.Id</MatButtonLink>
             </td>
             <td>
@@ -98,9 +98,10 @@
             <td>
                 Reviewed By: @context.ReviewedBy
             </td>
-            
+
         </MatTableRow>
     </MatTable>
+</MatThemeProvider>
 
 <!--
 <div class = "container DivToScroll">
@@ -136,11 +137,11 @@
     private bool _error; //this isn't used yet
     //TODO: error handling (what blazor pages returns)
     
- /*   private MatTheme _theme = new MatTheme()
+    private MatTheme _theme = new MatTheme()
     {
         Primary = MatThemeColors.Green._900.Value
     };
-*/
+
     protected override async Task OnInitializedAsync()
     {
         try

--- a/Annotations.Blazor/Components/Pages/Images/ImagesDatasetsReal.razor
+++ b/Annotations.Blazor/Components/Pages/Images/ImagesDatasetsReal.razor
@@ -6,18 +6,6 @@
 @inject IHttpContextAccessor httpContextAccessor
 @inject NavigationManager NavigationManager
 <style>
-    .DivToScroll{
-        background-color: #F5F5F5;
-        border: 1px solid #DDDDDD;
-        border-radius: 4px 0 4px 0;
-        color: #3B3C3E;
-        left: -1px;
-        max-height: 100vh;
-        overflow-x:hidden;/*this creates the scrollbar. It's appearance cannot be changed*/
-        padding: 1.5%;
-        scrollbar-width: auto;
-        max-width: 67vw;
-    }
     .orderingButton {/*for functionality later on*/
         border: 5px;
         cursor: pointer;
@@ -27,11 +15,6 @@
         margin-top:20%;
         margin-left: 10%;
         text-decoration: underline;
-    }
-    .ordering{/*maybe used for later*/
-        margin-left: 10%;
-        text-decoration: underline;
-        font-size: 130%;
     }
 
     .table-formatting {
@@ -87,7 +70,7 @@
                 <MatButtonLink href="@($"https://localhost:7238/images/datasets/{context.Id}")">Dataset: @context.Id</MatButtonLink>
             </td>
             <td>
-                Images in Dataset: ? <!-- TBD how to display all images in Dataset --->
+                Images in Dataset: @context.ImageIds.Count
             </td>
             <td>
                 Category: @context.Category
@@ -103,36 +86,7 @@
     </MatTable>
 </MatThemeProvider>
 
-<!--
-<div class = "container DivToScroll">
-    @foreach (var name in datasetslist)//TODO: dont hardcode these values (e.g. number of images)
-    {
-        <div class="datasetContainers">
-            <div style=" display: flex; flex-direction:row; flex-wrap: nowrap">
-                <span class = "textForDatasetsA" style="font-weight: bold">Dataset @name</span>
-                <span class = "textForDatasetsB">Annotated by: 1 person</span>
-            </div>
-            <div style=" display: flex; flex-direction:row; flex-wrap: nowrap">
-                <span class = "textForDatasetsA">Number of images: 3</span>
-                <span class = "textForDatasetsB">Reviewed by: 1 person</span>
-            </div>
-            <div style=" display: flex; flex-direction:row; flex-wrap: nowrap">
-                <span style="padding:0; margin: 0;  width: 95.5%;">Category: "?"</span>
-                <a href="https://localhost:7238/images/datasets/@name"><img src="https://www.svgrepo.com/download/64793/inverted-triangle.svg" alt="small black arrow pointing downwards" style="max-height: 30px; width:auto; margin-top: 0.1%; margin-bottom: 0.0001%">
-                </a>
-            </div>
-        </div>
-    }
-    <MatButton OnClick="@PageNumberNext">Next page</MatButton>
-    @if (PageNumber > 1) {
-    <MatButton OnClick="@PageNumberPrev">Previous page</MatButton>
-    }
-</div>
---->
-
 @code{
-    //[Parameter] public int PageNumber {get; set;} = 1;
-    
     public List<Dataset>? Datasets = new List<Dataset>();//it only works as a list, not an array
     private bool _error; //this isn't used yet
     //TODO: error handling (what blazor pages returns)
@@ -202,26 +156,4 @@
             ReviewedBy = reviewedBy;
         }
     }
-
-    /*
-    public int IncreasePageNumber ()
-    {
-        return PageNumber++;
-    }
-    
-    public int DecreasePageNumber ()
-    {
-        return PageNumber--;
-    }
-
-    public void PageNumberNext (MouseEventArgs e) {
-        //public int NewPage = IncreasePageNumber();
-        //needs logic for changing pagenumber
-    }
-
-    public void PageNumberPrev (MouseEventArgs e) {
-        //public int NewPage = DecreasePageNumber();
-        //needs logic for changing pagenumber
-    }
-    */
 }

--- a/Annotations.Blazor/Components/Pages/Images/ImagesDatasetsReal.razor
+++ b/Annotations.Blazor/Components/Pages/Images/ImagesDatasetsReal.razor
@@ -1,23 +1,10 @@
-﻿@page "/images/datasets"
+﻿@page "/images/datasets/"
 @rendermode InteractiveServer
 @using Microsoft.AspNetCore.Authentication
 @inject IHttpClientFactory ClientFactory
 @inject IHttpContextAccessor httpContextAccessor
 @inject NavigationManager NavigationManager
 <style>
-    .container {
-        display: flex;
-        flex-direction: column;
-    }
-    .datasetContainers {
-        background-color: #e3e7ee;
-        padding-top: 0.8%;
-        padding-bottom: 0.3%;
-        padding-left: 1%;
-        margin-bottom: 1%;
-        margin-top: 1%;
-        border-radius: 10px 10px 10px 10px;
-    }
     .DivToScroll{
         background-color: #F5F5F5;
         border: 1px solid #DDDDDD;
@@ -45,17 +32,33 @@
         text-decoration: underline;
         font-size: 130%;
     }
-    .textForDatasetsA{/*used to control the width/placement*/
-        padding:0; /*makes it so the lines are close together*/
-        margin: 0; 
+
+    .table-formatting {
+        border-collapse: collapse;
+        border-spacing: 0;
+        display: inline-block;
+        overflow-x: auto;
+        margin-left: 10%;
+        margin-right: 10%;
         width: 80%;
+        background-color: #e3e7ee;
+        padding-top: 0.8%;
+        padding-bottom: 0.3%;
+        padding-left: 1%;
+        margin-bottom: 1%;
+        margin-top: 1%;
+        border-radius: 10px 10px 10px 10px;
     }
-    .textForDatasetsB {
-        padding:0; 
+
+    .table-formatting th, td {
+        padding:0;
         margin: 0; 
-        width: 21%
+        width: 5%;
+        border: none;
+        background: #e3e7ee;
     }
 </style>
+
 <div style=" display: flex; flex-direction:row;">
     <span style="margin-left:13%; margin-top:0.0001%; padding-bottom:2%; font-weight: bold; width: 72%; font-size: 215%">Manage datasets</span>
     <div style="width:15%">
@@ -63,34 +66,28 @@
     </div>
 </div>
 
-<MatThemeProvider Theme="_theme">
-    <MatTable Items="Datasets" class="mat-elevation-z5">
-        <MatTableHeader>
-            <th>Id</th>
-            <th>Images</th>
-            <th>Category</th>
-            <th>Annotated By</th>
-            <th>Reviewed By</th>
-        </MatTableHeader>
+
+    <MatTable Items="Datasets" class="table-formatting">
+
         <MatTableRow>
             <td>
                 <MatButtonLink href="@($"https://localhost:7238/images/datasets/{context.Id}")">Dataset: @context.Id</MatButtonLink>
             </td>
             <td>
-                Images in Dataset: ???
+                Images in Dataset: @context.ImageIds.Sum()
             </td>
             <td>
-                Category: ???
+                Category: @context.Category
             </td>
             <td>
-                Annotated By: ???
+                Annotated By: @context.AnnotatedBy
             </td>
             <td>
-                Reviewed By: ???
+                Reviewed By: @context.ReviewedBy
             </td>
         </MatTableRow>
     </MatTable>
-</MatThemeProvider>
+
 <!--
 <div class = "container DivToScroll">
     @foreach (var name in datasetslist)//TODO: dont hardcode these values (e.g. number of images)
@@ -119,17 +116,17 @@
 --->
 
 @code{
-    [Parameter] public int PageNumber {get; set;} = 1;
+    //[Parameter] public int PageNumber {get; set;} = 1;
     
     public List<Dataset>? Datasets = new List<Dataset>();//it only works as a list, not an array
     private bool _error; //this isn't used yet
     //TODO: error handling (what blazor pages returns)
     
-    private MatTheme _theme = new MatTheme()
+ /*   private MatTheme _theme = new MatTheme()
     {
         Primary = MatThemeColors.Green._900.Value
     };
-
+*/
     protected override async Task OnInitializedAsync()
     {
         try
@@ -144,10 +141,10 @@
             using var response = await client.SendAsync(requestMessage);//sending the response
             if (response.IsSuccessStatusCode)
             {
-                var existingIds = await response.Content.ReadFromJsonAsync<int[]>();//int array of all the ids of all the existing datasets
-                foreach (var id in existingIds)
+                var datasetmodels = await response.Content.ReadFromJsonAsync<int[]>();//int array of all the ids of all the existing datasets
+                foreach (var dataset in datasetmodels)
                 {
-                    Datasets.Add(new Dataset(id));
+                    Datasets.Add(new Dataset(dataset));
                 }
             }
             else
@@ -167,10 +164,21 @@
     public class Dataset
     {
         public int Id { get; set; }
+        public List<int> ImageIds{ get; set; }
+   
+        public string Category { get; set; }
+   
+        public int AnnotatedBy { get; set; }
+ 
+        public int ReviewedBy { get; set; }
         
         public Dataset(int id)
         {
             Id = id;
+            ImageIds = ImageIds;
+            Category = Category;
+            AnnotatedBy = AnnotatedBy;
+            ReviewedBy = ReviewedBy;
         }
     }
 

--- a/Annotations.Blazor/Components/Pages/Images/ImagesDatasetsReal.razor
+++ b/Annotations.Blazor/Components/Pages/Images/ImagesDatasetsReal.razor
@@ -1,4 +1,5 @@
 ﻿@page "/images/datasets/page={PageNumber:int}"
+@rendermode InteractiveServer
 @using Microsoft.AspNetCore.Authentication
 @inject IHttpClientFactory ClientFactory
 @inject IHttpContextAccessor httpContextAccessor
@@ -61,6 +62,23 @@
         <button class="orderingButton">Order by...</button>
     </div>
 </div>
+
+<MatTable Items="datasetslist" class="mat-elevation-z5">
+    <MatTableHeader>
+        <th>Id</th>
+        <th>Images</th>
+        <th>Category</th>
+        <th>Annotated By</th>
+        <th>Reviewed By</th>
+    </MatTableHeader>
+    <MatTableRow>
+        <td>
+            <MatButtonLink href="@($"https://localhost:7238/images/datasets/{context.Id}")">@context.Id</MatButtonLink>
+        </td>
+    </MatTableRow>
+</MatTable>
+
+<!--
 <div class = "container DivToScroll">
     @foreach (var name in datasetslist)//TODO: dont hardcode these values (e.g. number of images)
     {
@@ -85,14 +103,12 @@
     <MatButton OnClick="@PageNumberPrev">Previous page</MatButton>
     }
 </div>
-
-
-
+--->
 
 @code{
     [Parameter] public int PageNumber {get; set;} = 1;
     
-    public List<int>? datasetslist = new List<int>();//it only works as a list, not an array
+    public List<Dataset>? datasetslist = new List<Dataset>();//it only works as a list, not an array
     private bool error = false;//this isn't used yet
     //TODO: error handling (what blazor pages returns)
 
@@ -110,7 +126,7 @@
             var existingIds = await response.Content.ReadFromJsonAsync<int[]>();//int array of all the ids of all the existing datasets
             for (int i = 0; i < existingIds.Length; i++)
             {
-                datasetslist.Add(existingIds[i]);
+                datasetslist.Add(new Dataset(existingIds[i]));
             }
         }
         catch (Exception e)
@@ -138,5 +154,16 @@
     public void PageNumberPrev (MouseEventArgs e) {
         //public int NewPage = DecreasePageNumber();
         //needs logic for changing pagenumber
+    }
+    
+    // Dataset model - to be expanded
+    public class Dataset
+    {
+        public int Id { get; set; }
+        
+        public Dataset(int id)
+        {
+            Id = id;
+        }
     }
 }

--- a/Annotations.Blazor/Components/Pages/Images/ImagesDatasetsReal.razor
+++ b/Annotations.Blazor/Components/Pages/Images/ImagesDatasetsReal.razor
@@ -63,21 +63,34 @@
     </div>
 </div>
 
-<MatTable Items="datasetslist" class="mat-elevation-z5">
-    <MatTableHeader>
-        <th>Id</th>
-        <th>Images</th>
-        <th>Category</th>
-        <th>Annotated By</th>
-        <th>Reviewed By</th>
-    </MatTableHeader>
-    <MatTableRow>
-        <td>
-            <MatButtonLink href="@($"https://localhost:7238/images/datasets/{context.Id}")">Dataset: @context.Id</MatButtonLink>
-        </td>
-    </MatTableRow>
-</MatTable>
-
+<MatThemeProvider Theme="_theme">
+    <MatTable Items="Datasets" class="mat-elevation-z5">
+        <MatTableHeader>
+            <th>Id</th>
+            <th>Images</th>
+            <th>Category</th>
+            <th>Annotated By</th>
+            <th>Reviewed By</th>
+        </MatTableHeader>
+        <MatTableRow>
+            <td>
+                <MatButtonLink href="@($"https://localhost:7238/images/datasets/{context.Id}")">Dataset: @context.Id</MatButtonLink>
+            </td>
+            <td>
+                Images in Dataset: ???
+            </td>
+            <td>
+                Category: ???
+            </td>
+            <td>
+                Annotated By: ???
+            </td>
+            <td>
+                Reviewed By: ???
+            </td>
+        </MatTableRow>
+    </MatTable>
+</MatThemeProvider>
 <!--
 <div class = "container DivToScroll">
     @foreach (var name in datasetslist)//TODO: dont hardcode these values (e.g. number of images)
@@ -108,34 +121,60 @@
 @code{
     [Parameter] public int PageNumber {get; set;} = 1;
     
-    public List<Dataset>? datasetslist = new List<Dataset>();//it only works as a list, not an array
-    private bool error = false;//this isn't used yet
+    public List<Dataset>? Datasets = new List<Dataset>();//it only works as a list, not an array
+    private bool _error; //this isn't used yet
     //TODO: error handling (what blazor pages returns)
+    
+    private MatTheme _theme = new MatTheme()
+    {
+        Primary = MatThemeColors.Green._900.Value
+    };
 
     protected override async Task OnInitializedAsync()
     {
-        var httpContext = httpContextAccessor.HttpContext ?? throw new InvalidOperationException("No HttpContext available");//make connection
-        var accessToken = await httpContext.GetTokenAsync("access_token") ?? throw new InvalidOperationException("No access_token was saved");//authorization
-        var client = ClientFactory.CreateClient();
-        client.BaseAddress = new("https://localhost:7250");//connect to Web API
-        using var requestMessage = new HttpRequestMessage(HttpMethod.Get, $"/images/datasets/");//access endpoint
-        requestMessage.Headers.Authorization = new("Bearer", accessToken);//bearer token for authorization
-        using var response = await client.SendAsync(requestMessage);//sending the response
         try
         {
-            var existingIds = await response.Content.ReadFromJsonAsync<int[]>();//int array of all the ids of all the existing datasets
-            for (int i = 0; i < existingIds.Length; i++)
+            var httpContext = httpContextAccessor.HttpContext ?? throw new InvalidOperationException("No HttpContext available");//make connection
+            var accessToken = await httpContext.GetTokenAsync("access_token") ?? throw new InvalidOperationException("No access_token was saved");//authorization
+            var client = ClientFactory.CreateClient();
+            client.BaseAddress = new("https://localhost:7250");//connect to Web API
+            using var requestMessage = new HttpRequestMessage(HttpMethod.Get, $"/images/datasets/");//access endpoint
+            requestMessage.Headers.Authorization = new("Bearer", accessToken);//bearer token for authorization
+            
+            using var response = await client.SendAsync(requestMessage);//sending the response
+            if (response.IsSuccessStatusCode)
             {
-                datasetslist.Add(new Dataset(existingIds[i]));
+                var existingIds = await response.Content.ReadFromJsonAsync<int[]>();//int array of all the ids of all the existing datasets
+                foreach (var id in existingIds)
+                {
+                    Datasets.Add(new Dataset(id));
+                }
+            }
+            else
+            {
+                _error = true;
+                Console.WriteLine("Status code: " + response.StatusCode);
             }
         }
         catch (Exception e)
         {
-            Console.WriteLine("Status code: " + response.StatusCode);
-            error = true;
+            _error = true;
+            Console.WriteLine("Unknown error: " + e.Message);
+        }
+    }
+    
+    // Dataset model - to be expanded
+    public class Dataset
+    {
+        public int Id { get; set; }
+        
+        public Dataset(int id)
+        {
+            Id = id;
         }
     }
 
+    /*
     public int IncreasePageNumber ()
     {
         return PageNumber++;
@@ -155,15 +194,5 @@
         //public int NewPage = DecreasePageNumber();
         //needs logic for changing pagenumber
     }
-    
-    // Dataset model - to be expanded
-    public class Dataset
-    {
-        public int Id { get; set; }
-        
-        public Dataset(int id)
-        {
-            Id = id;
-        }
-    }
+    */
 }

--- a/Annotations.Blazor/Components/Pages/Images/ImagesDatasetsReal.razor
+++ b/Annotations.Blazor/Components/Pages/Images/ImagesDatasetsReal.razor
@@ -1,4 +1,4 @@
-﻿@page "/images/datasets/page={PageNumber:int}"
+﻿@page "/images/datasets"
 @rendermode InteractiveServer
 @using Microsoft.AspNetCore.Authentication
 @inject IHttpClientFactory ClientFactory
@@ -73,7 +73,7 @@
     </MatTableHeader>
     <MatTableRow>
         <td>
-            <MatButtonLink href="@($"https://localhost:7238/images/datasets/{context.Id}")">@context.Id</MatButtonLink>
+            <MatButtonLink href="@($"https://localhost:7238/images/datasets/{context.Id}")">Dataset: @context.Id</MatButtonLink>
         </td>
     </MatTableRow>
 </MatTable>


### PR DESCRIPTION
Obs! Commented code from **"Annotations.API/Groups/ImagesGroup.cs"** is removed in the following pull request.


Refactoring of /images/datasets to contain a table formatting, which enables easy pagination as well as decisions for the user of how many datasets they want to see on one page.