### PR TITLE
Lazy loading implemented + front end housekeeping

### DIFF
--- a/Annotations.API/Groups/ImagesGroup.cs
+++ b/Annotations.API/Groups/ImagesGroup.cs
@@ -225,8 +225,9 @@ public static class ImagesGroup
             {
                 var cts = new CancellationTokenSource(5000);
 
+                //Datasets from DBContext are transformed to DatasetModels
                 var datasets = await context.Datasets
-                    .Select(u => new DatasetModel()//is this too much?
+                    .Select(u => new DatasetModel()
                     {
                         Id = u.Id,
                         ImageIds = u.ImageIds,
@@ -235,16 +236,11 @@ public static class ImagesGroup
                         ReviewedBy = u.ReviewedBy
                     })
                     .ToListAsync();
-                int[] names = new int[datasets.Count];
-                int counter = 0;
-                foreach (DatasetModel dataset in datasets)//better way of doing this
-                {
-                    names[counter] = dataset.Id;
-                    counter++;
-                }
+                
+                //DatasetModel list is converted to Array for sending to Blazor front-end
+                DatasetModel[] datasetsarray = datasets.ToArray();
 
-                return names;//array of all ids of datasets
-
+                return datasetsarray;
 
             }).DisableAntiforgery();
         

--- a/Annotations.Blazor/Components/Layout/AvatarMenu.razor
+++ b/Annotations.Blazor/Components/Layout/AvatarMenu.razor
@@ -1,4 +1,3 @@
-@using MatBlazor
 @implements IDisposable
 @inject NavigationManager Navigation
 

--- a/Annotations.Blazor/Components/Layout/MainLayout.razor
+++ b/Annotations.Blazor/Components/Layout/MainLayout.razor
@@ -1,5 +1,4 @@
 ﻿@inherits LayoutComponentBase
-@using MatBlazor
 
 <div class="header">
     <div>

--- a/Annotations.Blazor/Components/Pages/ApiAccess.razor
+++ b/Annotations.Blazor/Components/Pages/ApiAccess.razor
@@ -1,6 +1,4 @@
 ﻿@page "/ApiAccess"
-@using Microsoft.AspNetCore.Authentication
-@using Microsoft.AspNetCore.Authorization
 @using System.Text.Json;
 @inject IHttpClientFactory ClientFactory
 @inject IHttpContextAccessor httpContextAccessor

--- a/Annotations.Blazor/Components/Pages/Home.razor
+++ b/Annotations.Blazor/Components/Pages/Home.razor
@@ -1,5 +1,4 @@
 ﻿@page "/"
-@using MatBlazor
 @implements IDisposable
 @inject NavigationManager Navigation
 @rendermode InteractiveServer

--- a/Annotations.Blazor/Components/Pages/Images/Images.razor
+++ b/Annotations.Blazor/Components/Pages/Images/Images.razor
@@ -1,4 +1,3 @@
-@using Microsoft.AspNetCore.Authentication
 @page "/images/{imageId}"
 @using global::Annotations.Core.Models
 
@@ -11,8 +10,9 @@
 }
 else
 {
-    <img src="data:image;base64, @image" alt="@altText" /><!--src is a URL - it's converted from a string of the byte array--> 
-
+    <div class="container DivToScroll">
+        <img class="displaySoloImage" src="data:image;base64, @image" alt="@altText" /><!--src is a URL - it's converted from a string of the byte array--> 
+    </div>
 }
 @code{
 

--- a/Annotations.Blazor/Components/Pages/Images/ImagesDatasetImages.razor
+++ b/Annotations.Blazor/Components/Pages/Images/ImagesDatasetImages.razor
@@ -1,116 +1,112 @@
-﻿@page "/images/datasets/{dataset}"
-@using MatBlazor
-@using Microsoft.AspNetCore.Authentication
+﻿@rendermode InteractiveServer
+@page "/images/datasets/{dataset}/"
 @using global::Annotations.Core.Models
-@using Microsoft.AspNetCore.Authentication
 @inject IHttpClientFactory ClientFactory
 @inject IHttpContextAccessor httpContextAccessor
 
-<style>
-    .displayImages {/*images are a third - three images per line*/
-        width: 33%;
-        padding: 1%;
-
-    }
-    .container {
-        display: flex;
-        flex-direction: row;
-        flex-wrap: wrap;
-    
-    }
-    .DivToScroll{
-        background-color: #F5F5F5;
-        border: 1px solid #DDDDDD;
-        border-radius: 4px 0 4px 0;
-        color: #3B3C3E;
-        left: -1px;
-        max-height: 100vh;
-        overflow-x:hidden;/*this creates the scrollbar. It's appearance cannot be changed*/
-        padding: 1.5%;
-        scrollbar-width: auto;
-    }
-    .filterButton {/*for functionality later on*/
-        text-align: right; 
-        width: 10%;
-        border: 5px;
-        cursor: pointer;
-        background-color: transparent;
-        font-size: 110%;
-        margin-right: 3%;
-        text-decoration: underline;
-    }
-
   
-</style>
-
-
-@if (images==null)//TODO: better error handling - this doesn't even work
+@if (images == null) //This will show on screen in a milisecond before imgs load. Should it be "Loading..."?
 {
-    <p><em>No images found</em></p>
+    <p><em>This Dataset is empty.</em></p>
 }
 else
 {
     <div style=" display: flex; flex-direction:row;"><!--To make both lines on the same row -->
-        
         <span style="padding:2%; font-weight: bold; width: 90%; font-size: 215%">Dataset @dataset</span>
         <button class="filterButton">Filter by...</button>
-        
     </div>
 
-    
-   
-        
     <div class="container DivToScroll" >
-        @for (int i = 0; i < images.Length; i++)
-        {
-            <img class = "displayImages" src="data:image;base64, @images[i]" alt="@altText[i]" /><!--src is a URL - it's converted from a string of the byte array--> 
-        }
-    </div>
-    
-   
-
-
-
+    <!--Virtualize is a special loop that loops OverscanCount data - here the imgs received from API-->
+        <Virtualize ItemsProvider="@LoadImages" OverscanCount="15">
+            <!--OverscanCount must always be divisible by 3! As we have 3 imgs per line-->
+            <!--It represents the number of images loaded before and after current position-->
+            <ItemContent>
+                <img class="displayImages" src="@GetImageSource(@context.Base64Data)" alt="@context.AltText" />
+            </ItemContent>
+        </Virtualize> 
+    </div> 
 }
+
 @code{
     //TODO: code duplication from Image.Filter.razor
-    [Parameter] public string dataset { get; set; }//get access to parameter from URL/get request
-    private string[]? images;//all byte arrays as strings
-    private string[]? altText;
-
+    [Parameter] public string dataset { get; set; } //get access to parameter from URL/get request
+    public ImageModelWeb[]? images; //all imgs from API turned into local datatype class (see further down)
+    
+    //Will run when site is initialized
     protected override async Task OnInitializedAsync()
     {
-        var httpContext = httpContextAccessor.HttpContext ?? throw new InvalidOperationException("No HttpContext available");//make connection
+        //make connection to website
+        var httpContext = httpContextAccessor.HttpContext ?? throw new InvalidOperationException("No HttpContext available");
 
-        var accessToken = await httpContext.GetTokenAsync("access_token") ?? throw new InvalidOperationException("No access_token was saved");//authorization
-
+        //authorization
+        var accessToken = await httpContext.GetTokenAsync("access_token") ?? throw new InvalidOperationException("No access_token was saved");
+        
         var client = ClientFactory.CreateClient();
-        client.BaseAddress = new("https://localhost:7250");//connect to Web API
+        
+        //connect to Web API
+        client.BaseAddress = new("https://localhost:7250");
 
-        using var requestMessage = new HttpRequestMessage(HttpMethod.Get, $"/images/datasets/{dataset}");//access endpoint
-        requestMessage.Headers.Authorization = new("Bearer", accessToken);//bearer token for authorization
+        //access endpoint
+        using var requestMessage = new HttpRequestMessage(HttpMethod.Get, $"/images/datasets/{dataset}");
 
-        using var response = await client.SendAsync(requestMessage);//sending the response
+        //bearer token for authorization
+        requestMessage.Headers.Authorization = new("Bearer", accessToken);
+
+        //sending the response
+        using var response = await client.SendAsync(requestMessage);
+        
         try
         {
-            string[] answer = await response.Content.ReadFromJsonAsync<string[]>();//string array of JSON files of the images as strings
-            images = new string[answer.Length];
-            altText = new string[answer.Length];
+            //string array of JSON files of the images as strings
+            string[] answer = await response.Content.ReadFromJsonAsync<string[]>();
+            
+            //initialize array for storing images to be shown on the webpage
+            images = new ImageModelWeb[answer.Length];
+            
             for (int i = 0; i < answer.Length; i++)
             {
-                var imageObject = System.Text.Json.JsonSerializer.Deserialize<ImageModel>(answer[i]);//JSON file becomes imageModel object
+                //JSON file becomes ImageModel object
+                var imageObject = System.Text.Json.JsonSerializer.Deserialize<ImageModel>(answer[i]);
+                
+                //Byte array data for the image
                 var imageData = imageObject.ImageData;
-                images[i] = System.Convert.ToBase64String(imageData);//byte array to string
-                altText[i] = imageObject.Description;
+
+                //Adding Base64 data and alt text as local ImageModel type to array
+                images[i] = new ImageModelWeb (System.Convert.ToBase64String(imageData), imageObject.Description);
             }
         }
         catch (Exception e)//if nothing is retrieved - prints out error
         {
             Console.WriteLine("Status code: " + response.StatusCode);
-            images = new string[1];
-            images[0] = response.StatusCode.ToString();
+            images = new ImageModelWeb[1];
+            images[0] = new ImageModelWeb(null, response.StatusCode.ToString());
         }
-
     }
 
+    //local datatype class for images
+    public class ImageModelWeb 
+    {
+        public string Base64Data {get; set;}
+        public string AltText {get; set;}
+        
+        public ImageModelWeb (string Base64DataInput, string AltTextInput) {
+            Base64Data = Base64DataInput;
+            AltText = AltTextInput;
+        }
+    }
+
+    /* Define an item provider - IEnumerable of items to iterate over for Virtualize 
+        Code inspired by: https://toxigon.com/implementing-lazy-loading-in-blazor */
+    private async ValueTask<ItemsProviderResult<ImageModelWeb>> LoadImages(ItemsProviderRequest request)
+    {
+        return new ItemsProviderResult<ImageModelWeb>(images, images.Length);
+    } 
+
+    /* Converts the image base64 string into an url the website can render
+        as an image. */
+    public string GetImageSource(string base64)
+    {
+        return $"data:image;base64,{base64}";
+    }
 }

--- a/Annotations.Blazor/Components/Pages/Images/ImagesDatasetsReal.razor
+++ b/Annotations.Blazor/Components/Pages/Images/ImagesDatasetsReal.razor
@@ -1,126 +1,114 @@
-﻿@page "/images/datasets"
-@using Microsoft.AspNetCore.Authentication
-
+﻿@page "/images/datasets/"
+@rendermode InteractiveServer
+@using global::Annotations.Core.Models
 @inject IHttpClientFactory ClientFactory
 @inject IHttpContextAccessor httpContextAccessor
-<style>
-    .container {
-        display: flex;
-        flex-direction: column;
-    }
-    .datasetContainers {
-        background-color: #e3e7ee;
-        padding-top: 0.8%;
-        padding-bottom: 0.3%;
-        padding-left: 1%;
-        margin-bottom: 1%;
-        margin-top: 1%;
-        border-radius: 10px 10px 10px 10px;
-    }
-    .DivToScroll{
-        background-color: #F5F5F5;
-        border: 1px solid #DDDDDD;
-        border-radius: 4px 0 4px 0;
-        color: #3B3C3E;
-        left: -1px;
-        max-height: 100vh;
-        overflow-x:hidden;/*this creates the scrollbar. It's appearance cannot be changed*/
-        padding: 1.5%;
-        scrollbar-width: auto;
-        max-width: 67vw;
-    }
-    .orderingButton {/*for functionality later on*/
-        border: 5px;
-        cursor: pointer;
-        background-color: transparent;
-        font-size: 130%;
-        text-align: center;
-        margin-top:20%;
-        margin-left: 10%;
-        text-decoration: underline;
-    }
-    .ordering{/*maybe used for later*/
-        margin-left: 10%;
-        text-decoration: underline;
-        font-size: 130%;
-    }
-    .textForDatasetsA{/*used to control the width/placement*/
-        padding:0; /*makes it so the lines are close together*/
-        margin: 0; 
-        width: 80%;
-    }
-    .textForDatasetsB {
-        padding:0; 
-        margin: 0; 
-        width: 21%
-    }
+@inject NavigationManager NavigationManager
 
-</style>
 <div style=" display: flex; flex-direction:row;">
-
     <span style="margin-left:13%; margin-top:0.0001%; padding-bottom:2%; font-weight: bold; width: 72%; font-size: 215%">Manage datasets</span>
     <div style="width:15%">
         <button class="orderingButton">Order by...</button>
     </div>
-
-</div>
-<div class = "container DivToScroll">
-    @foreach (var name in datasets)//TODO: dont hardcode these values (e.g. number of images)
-    {
-        <div class="datasetContainers">
-            <div style=" display: flex; flex-direction:row; flex-wrap: nowrap">
-                <span class = "textForDatasetsA" style="font-weight: bold">Dataset @name</span>
-                <span class = "textForDatasetsB">Annotated by: 1 person</span>
-            </div>
-            <div style=" display: flex; flex-direction:row; flex-wrap: nowrap">
-                <span class = "textForDatasetsA">Number of images: 3</span>
-                <span class = "textForDatasetsB">Reviewed by: 1 person</span>
-            </div>
-            <div style=" display: flex; flex-direction:row; flex-wrap: nowrap">
-                <span style="padding:0; margin: 0;  width: 95.5%;">Category: "?"</span>
-                <a href="https://localhost:7238/images/datasets/@name"><img src="https://www.svgrepo.com/download/64793/inverted-triangle.svg" alt="small black arrow pointing downwards" style="max-height: 30px; width:auto; margin-top: 0.1%; margin-bottom: 0.0001%">
-                </a>
-            </div>
-        </div>
-    }
 </div>
 
-
-
-
+<MatThemeProvider Theme="_theme">
+    <MatTable Items="Datasets" class="table-formatting">
+        <MatTableHeader>
+            <th>Dataset ID</th>
+            <th>No. of Images</th>
+            <th>Category</th>
+            <th>Annotated By</th>
+            <th>Reviewed By</th>
+        </MatTableHeader>
+        <MatTableRow>
+            <td>
+                <MatButtonLink href="@($"https://localhost:7238/images/datasets/{context.Id}")">@context.Id</MatButtonLink>
+            </td>
+            <td>
+                @context.ImageIds.Count
+            </td>
+            <td>
+                @context.Category
+            </td>
+            <td>
+                @context.AnnotatedBy
+            </td>
+            <td>
+                @context.ReviewedBy
+            </td>
+        </MatTableRow>
+    </MatTable>
+</MatThemeProvider>
 
 @code{
-    public List<int>? datasets = new List<int>();//it only works as a list, not an array
-    private bool error = false;//this isn't used yet
+    public List<Dataset>? Datasets = new List<Dataset>();//it only works as a list, not an array
+    private bool _error; //this isn't used yet
     //TODO: error handling (what blazor pages returns)
+    
+    private MatTheme _theme = new MatTheme()
+    {
+        Primary = MatThemeColors.Green._800.Value
+    };
 
     protected override async Task OnInitializedAsync()
     {
-        var httpContext = httpContextAccessor.HttpContext ?? throw new InvalidOperationException("No HttpContext available");//make connection
-
-        var accessToken = await httpContext.GetTokenAsync("access_token") ?? throw new InvalidOperationException("No access_token was saved");//authorization
-
-        var client = ClientFactory.CreateClient();
-        client.BaseAddress = new("https://localhost:7250");//connect to Web API
-
-        using var requestMessage = new HttpRequestMessage(HttpMethod.Get, $"/images/datasets");//access endpoint
-        requestMessage.Headers.Authorization = new("Bearer", accessToken);//bearer token for authorization
-
-        using var response = await client.SendAsync(requestMessage);//sending the response
         try
         {
-            var existingIds = await response.Content.ReadFromJsonAsync<int[]>();//int array of all the ids of all the existing datasets
-            for (int i = 0; i < existingIds.Length; i++)
+            var httpContext = httpContextAccessor.HttpContext ?? throw new InvalidOperationException("No HttpContext available");//make connection
+            var accessToken = await httpContext.GetTokenAsync("access_token") ?? throw new InvalidOperationException("No access_token was saved");//authorization
+            var client = ClientFactory.CreateClient();
+            client.BaseAddress = new("https://localhost:7250");//connect to Web API
+            using var requestMessage = new HttpRequestMessage(HttpMethod.Get, $"/images/datasets/");//access endpoint
+            requestMessage.Headers.Authorization = new("Bearer", accessToken);//bearer token for authorization
+            
+            using var response = await client.SendAsync(requestMessage);//sending the response
+            if (response.IsSuccessStatusCode)
             {
-                datasets.Add(existingIds[i]);
+                var datasetmodels = await response.Content.ReadFromJsonAsync<DatasetModel[]>();//int array of all the ids of all the existing datasets
+                foreach (var datasetmodel in datasetmodels)
+                {
+                    Datasets.Add(new Dataset(datasetmodel.Id,
+                    datasetmodel.ImageIds,
+                    datasetmodel.Category,
+                    datasetmodel.AnnotatedBy,
+                    datasetmodel.ReviewedBy));
+                }
+            }
+
+            else
+            {
+                _error = true;
+                Console.WriteLine("Status code: " + response.StatusCode);
             }
         }
         catch (Exception e)
         {
-            Console.WriteLine("Status code: " + response.StatusCode);
-            error = true;
+            _error = true;
+            Console.WriteLine("Unknown error: " + e.Message);
         }
-
     }
-
+    
+    // Dataset model - to be expanded
+    public class Dataset
+    {
+        public int Id { get; set; }
+        
+        public List<int> ImageIds{ get; set; }
+   
+        public string Category { get; set; }
+   
+        public int AnnotatedBy { get; set; }
+ 
+        public int ReviewedBy { get; set; }
+        
+        public Dataset(int id, List<int> imageIds, string category, int annotatedBy, int reviewedBy)
+        {
+            Id = id;
+            ImageIds = imageIds;
+            Category = category;
+            AnnotatedBy = annotatedBy;
+            ReviewedBy = reviewedBy;
+        }
+    }
 }

--- a/Annotations.Blazor/Components/Pages/Images/ImagesFilter.razor
+++ b/Annotations.Blazor/Components/Pages/Images/ImagesFilter.razor
@@ -1,47 +1,7 @@
-﻿@using MatBlazor
-@using Microsoft.AspNetCore.Authentication
-@page "/images/filter/{category}"
+﻿@page "/images/filter/{category}"
 @using global::Annotations.Core.Models
-@using Microsoft.AspNetCore.Authentication
 @inject IHttpClientFactory ClientFactory
 @inject IHttpContextAccessor httpContextAccessor
-
-<style>
-    .displayImages {/*images are a third - three images per line*/
-        width: 33%;
-        padding: 1%;
-
-    }
-    .container {
-        display: flex;
-        flex-direction: row;
-        flex-wrap: wrap;
-    
-    }
-    .DivToScroll{
-        background-color: #F5F5F5;
-        border: 1px solid #DDDDDD;
-        border-radius: 4px 0 4px 0;
-        color: #3B3C3E;
-        left: -1px;
-        max-height: 100vh;
-        overflow-x:hidden;/*this creates the scrollbar. It's appearance cannot be changed*/
-        padding: 1.5%;
-        scrollbar-width: auto;
-    }
-    .filterButton {/*for functionality later on*/
-        text-align: right; 
-        width: 10%;
-        border: 5px;
-        cursor: pointer;
-        background-color: transparent;
-        font-size: 110%;
-        margin-right: 3%;
-        text-decoration: underline;
-    }
-
-  
-</style>
 
 
 @if (images==null)//TODO: better error handling - this doesn't even work
@@ -64,12 +24,8 @@ else
             <img class="displayImages" alt="@altText[i]" src="data:image;base64, @images[i]"/><!--src is a URL - it's converted from a string of the byte array-->
         }
     </div>
-    
-   
-
-
-
 }
+
 @code{
     [Parameter] public string category { get; set; }//get access to parameter from URL/get request
     private string[]? images;//all byte arrays as strings

--- a/Annotations.Blazor/Components/_Imports.razor
+++ b/Annotations.Blazor/Components/_Imports.razor
@@ -8,3 +8,5 @@
 @using Microsoft.JSInterop
 @using Microsoft.AspNetCore.Components.Authorization
 @using MatBlazor
+@using Microsoft.AspNetCore.Authentication
+@using Microsoft.AspNetCore.Authorization

--- a/Annotations.Blazor/wwwroot/app.css
+++ b/Annotations.Blazor/wwwroot/app.css
@@ -102,3 +102,160 @@ h1:focus {
     opacity: 90%;
     color: white;
 }
+
+.container {
+    display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
+    overflow-y:scroll;
+}
+
+.DivToScroll{
+    background-color: #F5F5F5;
+    border: 1px solid #DDDDDD;
+    border-radius: 4px 0 4px 0;
+    color: #3B3C3E;
+    left: -1px;
+    max-height: 100vh;
+    overflow-x:hidden;/*this creates the scrollbar. It's appearance cannot be changed*/
+    padding: 1.5%;
+    scrollbar-width: auto;
+}
+
+.filterButton {/*for functionality later on*/
+    text-align: right; 
+    width: 10%;
+    border: 5px;
+    cursor: pointer;
+    background-color: transparent;
+    font-size: 110%;
+    margin-right: 3%;
+    text-decoration: underline;
+}
+
+.orderingButton {/*for functionality later on*/
+    border: 5px;
+    cursor: pointer;
+    background-color: transparent;
+    font-size: 130%;
+    text-align: center;
+    margin-top:20%;
+    margin-left: 10%;
+    text-decoration: underline;
+}
+
+.table-formatting {
+    display: block; /* Required for margin: auto to work */
+    position: relative;
+    border-collapse: collapse;
+    border-spacing: 0;
+    overflow-x: auto;
+    margin: 1% auto; /* Centers horizontally and keeps vertical margin */
+    width: 41.5%;
+    background-color: #e3e7ee;
+    padding: 0.8% 1% 0.3% 1%; /* Shorthand for top, right, bottom, left */
+    border-radius: 10px;
+    text-align: center;
+}
+
+.table-formatting th {
+    text-align: center;
+    padding:0;
+    margin: 2%; 
+    width: 22.5%;
+    height: 0%;
+    font-size: 1rem;
+    border: none;
+    background: #e3e7ee;
+}
+
+.table-formatting td {
+    text-align: center;
+    padding:0;
+    margin: 2%; 
+
+    width: 22.5%;
+    background: #e3e7ee;
+}
+
+.table-formatting tr > td:nth-child(1) {
+    width: 20%; 
+    max-width: 20%;
+    min-width: 20%;
+}
+
+.table-formatting th:nth-child(1){
+    width: 20%; 
+    max-width: 20%;
+    min-width: 20%;
+}
+
+.table-formatting tr > td:nth-child(2) {
+    width: 20%; 
+    max-width: 20%;
+    min-width: 20%;
+}
+
+.table-formatting th:nth-child(2) {
+    width: 20%; 
+    max-width: 20%;
+    min-width: 20%;
+}
+
+.table-formatting tr > td:nth-child(3) {
+    width: 30%; 
+    max-width: 30%;
+    min-width: 30%;
+}
+
+.table-formatting th:nth-child(3) {
+    width: 30%; 
+    max-width: 30%;
+    min-width: 30%;
+}
+
+.table-formatting tr > td:nth-child(4) {
+    width: 20%; 
+    max-width: 20%;
+    min-width: 20%;
+}
+
+.table-formatting th:nth-child(4) {
+    width: 20%; 
+    max-width: 20%;
+    min-width: 20%;
+}
+
+.table-formatting tr > td:nth-child(5) {
+    width: 20%; 
+    max-width: 20%;
+    min-width: 20%;
+}
+
+.table-formatting th:nth-child(5) {
+    width: 20%; 
+    max-width: 20%;
+    min-width: 20%;
+}
+
+.filterButton {/*for functionality later on*/
+    text-align: right; 
+    width: 10%;
+    border: 5px;
+    cursor: pointer;
+    background-color: transparent;
+    font-size: 110%;
+    margin-right: 3%;
+    text-decoration: underline;
+}
+
+.displayImages {/*images are a third - three images per line*/
+    width: 33%;
+    height: 33%;
+    padding: 1%;
+}
+
+.displaySoloImage {/*images are a third - three images per line*/
+    width: 100%;
+    height: 100%;
+}


### PR DESCRIPTION
## Classes most important to look at:
Annotations.API/Groups/ImagesGroup.cs
Annotations.Blazor/Components/Pages/Images/ImagesDatasetImages.razor

## Two new main features on this branch:

### Lazy loading for images in datasets (/images/datasets/{DatasetId}).
Lazy loading is implemented by using the Blazor functionality 'Virtualize'. Virtualize is a form of 'for' loop, that iterates over a collection, and let's you return x number of components at a time. The 'overscan' count determines how many elements directly before and after what is currently on the user's screen, that will be loaded. This number always needs to be divisible by 3, as we show 3 images on a line.

Images on this endpoint now get converted to a local datatype class, 'ImagesModelWeb', which can hold both imagedata as well as alt text.

### Implementation of Dataset local datattype class for Datasets on /images/datasets.
Like with above, Datasets get converted to a local datatype class, such that we can access several fields from the API Datatype.



## Minor features:
All css I could find in .razor pages has been moved to app.css. app.css is a general css class that can be applied to all component pages. As such, css for all image endpoints has been re-used, fx.

Unnescessary 'using' statements from most .razor classes have been removed. In _Imports.razor, we can define using that we wish to use on several .razor pages. I have therefore moved 'using' statements that are duplicated over several .razor classes to this class.