### PR TITLE
Feature/pt 77 revise how trees are built

### DIFF
--- a/Annotations.Blazor/Components/Pages/Annotations/AnnotateOnImage.razor
+++ b/Annotations.Blazor/Components/Pages/Annotations/AnnotateOnImage.razor
@@ -146,12 +146,15 @@
 
                                 @foreach (var point in _drawablePoints)
                                 {
-                                    <circle cx="@point.X" cy="@point.Y" r="10"
-                                            fill="white" stroke="white"
-                                            stroke-width="2"
-                                            @onpointerdown="@(e => StartDrag(e, point))"
-                                            @onclick="@(() => HandlePointClick(point))"
-                                            class="MatOverwriteCursor"/>
+                                    if (point.isVisible)
+                                    {
+                                        <circle cx="@point.X" cy="@point.Y" r="10"
+                                                fill="white" stroke="white"
+                                                stroke-width="2"
+                                                @onpointerdown="@(e => StartDrag(e, point))"
+                                                @onclick="@(() => HandlePointClick(point))"
+                                                class="MatOverwriteCursor"/>
+                                    }
                                 }
 
                                 @if (_currentVesselAnnotation != null)
@@ -192,13 +195,18 @@
                                 var i1 = i;
                                 <MatExpansionPanel>
                                     <MatExpansionPanelSummary>
+
                                         <MatExpansionPanelHeader> Tree @i1 </MatExpansionPanelHeader>
                                     </MatExpansionPanelSummary>
                                     <MatExpansionPanelDetails>
                                         @for (var j = 0; j < _savedVessels[i1].Points.Count; j++)
                                         {
                                             var j1 = j;
+                                            var point = _savedVessels[i1].Points[j1];
                                             <p> point @j </p>
+                                            
+                                            <MatIconButton Icon="visibility" OnClick="() => point!.isVisible = false">
+                                            </MatIconButton>
                                         }
                                     </MatExpansionPanelDetails>
                                 </MatExpansionPanel>
@@ -322,6 +330,7 @@
             }
         }
 
+        _currentPoint.isVisible = true;
         _showTextField = false;
         StateHasChanged();
         PrecomputeAnnotations();
@@ -427,6 +436,7 @@
 
     private class VesselPoint
     {
+        public bool isVisible;
         public int X { get; set; }
         public int Y { get; set; }
         public string Text { get; set; } = "";
@@ -451,5 +461,10 @@
     }
 
     [Inject] private IJSRuntime JsRuntime { get; set; } = default!;
+
+    private void toggleVisibillity(MouseEventArgs obj)
+    {
+        throw new NotImplementedException();
+    }
 
 }

--- a/Annotations.Blazor/Components/Pages/Annotations/AnnotateOnImage.razor
+++ b/Annotations.Blazor/Components/Pages/Annotations/AnnotateOnImage.razor
@@ -205,7 +205,7 @@
                                             var point = _savedVessels[i1].Points[j1];
                                             <p> point @j </p>
                                             
-                                            <MatIconButton Icon="visibility" OnClick="() => point!.isVisible = false">
+                                            <MatIconButton Icon="visibility_off" ToggleIcon="visibility" @bind-Toggled = "@point!.isVisible">
                                             </MatIconButton>
                                         }
                                     </MatExpansionPanelDetails>

--- a/Annotations.Blazor/Components/Pages/Annotations/AnnotateOnImage.razor
+++ b/Annotations.Blazor/Components/Pages/Annotations/AnnotateOnImage.razor
@@ -86,14 +86,6 @@
                                 </div>
                             </MatRadioGroup>
                         </div>
-                        
-                        <!--    
-                            <MatCheckbox @bind-Value="@_arteriesMarked">Arteries marked</MatCheckbox>
-                        </div>
-                        <div>
-                            <MatCheckbox @bind-Value="@_veinsMarked">Veins marked</MatCheckbox>
-                        </div>
-                        --->
                         </div>
                     <div class="mat-layout-grid-cell mat-layout-grid-cell-span-10">
                         <div class="mat-layout-grid-inner">
@@ -157,6 +149,7 @@
                                             fill="white" stroke="white"
                                             stroke-width="2"
                                             @onpointerdown="@(e => StartDrag(e, point))"
+                                            @onclick="@(() => HandlePointClick(point))"
                                             class="MatOverwriteCursor"/>
                                 }
 
@@ -183,6 +176,7 @@
                                         <circle cx="@point!.X" cy="@point.Y" r="10"
                                                 fill="white" stroke="white"
                                                 stroke-width="2"
+                                                @onclick="@(() => HandlePointClick(point))"
                                                 @onpointerdown="@(e => StartDrag(e, point))"
                                                 class="MatOverwriteCursor"/>
                                     }
@@ -258,6 +252,14 @@
         StateHasChanged();
     }
 
+    
+    private void HandlePointClick(VesselPoint point)
+    {
+        _currentPoint = point;
+        
+        
+    }
+    
     public void Dispose() => Navigation.LocationChanged -= OnLocationChanged;
 
     private void PrecomputeAnnotations()
@@ -279,7 +281,7 @@
         }
     }
 
-    private void SavePointAnnotation()
+    private void SavePointAnnotation(VesselPoint lastPoint)
     {
         if (_currentVesselAnnotation != null)
         {
@@ -287,7 +289,6 @@
 
             if (_currentVesselAnnotation.Points.Count > 1)
             {
-                var lastPoint = _currentVesselAnnotation.Points[^2];
                 var segment = new VesselSegment
                 {
                     StartPoint = lastPoint,
@@ -365,6 +366,7 @@
         var rect = await JsRuntime.InvokeAsync<BoundingClientRect>(
             "getBoundingClientRect", _imageContainer);
 
+        var lastPoint = _currentPoint; 
         _currentPoint = new VesselPoint
         {
             X = (int)(e.ClientX - rect.Left),
@@ -372,7 +374,7 @@
             Type = _currentVesselType
         };
 
-        SavePointAnnotation();
+        SavePointAnnotation(lastPoint);
 
         StateHasChanged();
     }
@@ -429,4 +431,5 @@
     }
 
     [Inject] private IJSRuntime JsRuntime { get; set; } = default!;
+
 }

--- a/Annotations.Blazor/Components/Pages/Annotations/AnnotateOnImage.razor
+++ b/Annotations.Blazor/Components/Pages/Annotations/AnnotateOnImage.razor
@@ -76,12 +76,20 @@
                             </div>
                         </div>
                         <div class="MatOverwriteMarginTop50">
+                            <MatRadioGroup @bind-Value="@_currentVesselAnnotation.Type">
+                                <MatRadioButton TValue="string">Arteries</MatRadioButton>
+                                <MatRadioButton TValue="string">Veins</MatRadioButton>
+                            </MatRadioGroup>
+                        </div>
+                        
+                        <!--    
                             <MatCheckbox @bind-Value="@_arteriesMarked">Arteries marked</MatCheckbox>
                         </div>
                         <div>
                             <MatCheckbox @bind-Value="@_veinsMarked">Veins marked</MatCheckbox>
                         </div>
-                    </div>
+                        --->
+                        </div>
                     <div class="mat-layout-grid-cell mat-layout-grid-cell-span-10">
                         <div class="mat-layout-grid-inner">
                             <div class="mat-layout-grid-cell mat-layout-grid-cell-span-3">
@@ -322,24 +330,15 @@
             return;
         }
         
-        if (_arteriesMarked && !_veinsMarked)
-        {
-            _currentVesselAnnotation.Type = "Artery";
-
-        } 
-        else if (!_arteriesMarked && _veinsMarked)
-        {
-            _currentVesselAnnotation.Type = "Vein";
-
-        }        
-        else
+        if (_currentVesselAnnotation.Type == "")
         {
             _completionTitle = "Fail";
-            _completionMessage = "Please choose a type. you can only choose one";
+            _completionMessage = "Please choose a type.";
             _showCompletionDialog = true;
             StateHasChanged();
             return;
-        }
+        } 
+
 
         _savedVessels.Add(_currentVesselAnnotation!);
         _currentVesselAnnotation = new VesselAnnotation();

--- a/Annotations.Blazor/Components/Pages/Annotations/AnnotateOnImage.razor
+++ b/Annotations.Blazor/Components/Pages/Annotations/AnnotateOnImage.razor
@@ -13,17 +13,10 @@
         <MatThemeProvider Theme="@_theme">
             <MatDialog @bind-IsOpen="@_showCompletionDialog">
                 <MatDialogTitle>@_completionTitle</MatDialogTitle>
-                <MatDialogContent>@_completionMessage</MatDialogContent>
-                <MatDialogActions>
-                    <MatButton OnClick="@(() => _showCompletionDialog = false)">OK</MatButton>
-                </MatDialogActions>
-            </MatDialog>
-
-            <MatDialog @bind-IsOpen="@_showTextField">
-                <MatDialogTitle>Blood vessel point annotation</MatDialogTitle>
                 <MatDialogContent>
+                    @_completionMessage
                     <p>
-                        <MatTextField @bind-Value="_currentPoint.Text"
+                        <MatTextField @bind-Value="_currentVesselAnnotation.Description"
                                       Label="Annotation"
                                       FullWidth="true"
                                       Immediate="true"
@@ -31,15 +24,9 @@
                                       class="MatOverwriteWhiteBG">
                         </MatTextField>
                     </p>
-                    <p>
-                        <MatSelectItem @bind-Value="@_currentPoint.Type" Label="Type" Items="@_types"></MatSelectItem>
-                    </p>
                 </MatDialogContent>
                 <MatDialogActions>
-                    <div>
-                        <MatButton class="MatOverwriteButton" OnClick="SavePointAnnotation">Save</MatButton>
-                        <MatButton class="MatOverwriteButton" OnClick="CancelPointAnnotation">Cancel</MatButton>
-                    </div>
+                    <MatButton OnClick="@(() => _showCompletionDialog = false)">OK</MatButton>
                 </MatDialogActions>
             </MatDialog>
 
@@ -363,7 +350,8 @@
             Type = _currentVesselType
         };
 
-        _showTextField = true;
+        SavePointAnnotation();
+
         StateHasChanged();
     }
 
@@ -414,6 +402,7 @@
     {
         public List<VesselPoint?> Points { get; } = new();
         public List<VesselSegment> Segments { get; } = new();
+        public string Description { get; set; } = "";
     }
 
     [Inject] private IJSRuntime JsRuntime { get; set; } = default!;

--- a/Annotations.Blazor/Components/Pages/Annotations/AnnotateOnImage.razor
+++ b/Annotations.Blazor/Components/Pages/Annotations/AnnotateOnImage.razor
@@ -15,15 +15,18 @@
                 <MatDialogTitle>@_completionTitle</MatDialogTitle>
                 <MatDialogContent>
                     @_completionMessage
-                    <p>
-                        <MatTextField @bind-Value="_currentVesselAnnotation.Description"
-                                      Label="Annotation"
-                                      FullWidth="true"
-                                      Immediate="true"
-                                      Id="annotationTextField"
-                                      class="MatOverwriteWhiteBG">
-                        </MatTextField>
-                    </p>
+                    @if (_completionTitle == "Success")
+                    {
+                        <p>
+                            <MatTextField @bind-Value="_currentVesselAnnotation.Description"
+                                          Label="Annotation"
+                                          FullWidth="true"
+                                          Immediate="true"
+                                          Id="annotationTextField"
+                                          class="MatOverwriteWhiteBG">
+                            </MatTextField>
+                        </p>
+                    }
                 </MatDialogContent>
                 <MatDialogActions>
                     <MatButton OnClick="@(() => _showCompletionDialog = false)">OK</MatButton>
@@ -77,12 +80,6 @@
                         </div>
                         <div>
                             <MatCheckbox @bind-Value="@_veinsMarked">Veins marked</MatCheckbox>
-                        </div>
-                        <div>
-                            <MatCheckbox @bind-Value="@_flowDirectionSet">Flow direction set</MatCheckbox>
-                        </div>
-                        <div>
-                            <MatCheckbox @bind-Value="@_videoReviewed">Video reviewed</MatCheckbox>
                         </div>
                     </div>
                     <div class="mat-layout-grid-cell mat-layout-grid-cell-span-10">
@@ -193,8 +190,6 @@
     private string? _currentUrl;
     private bool _arteriesMarked;
     private bool _veinsMarked;
-    private bool _flowDirectionSet;
-    private bool _videoReviewed;
 
     private bool _showCompletionDialog;
     private string _completionMessage = "";
@@ -326,6 +321,25 @@
             StateHasChanged();
             return;
         }
+        
+        if (_arteriesMarked && !_veinsMarked)
+        {
+            _currentVesselAnnotation.Type = "Artery";
+
+        } 
+        else if (!_arteriesMarked && _veinsMarked)
+        {
+            _currentVesselAnnotation.Type = "Vein";
+
+        }        
+        else
+        {
+            _completionTitle = "Fail";
+            _completionMessage = "Please choose a type. you can only choose one";
+            _showCompletionDialog = true;
+            StateHasChanged();
+            return;
+        }
 
         _savedVessels.Add(_currentVesselAnnotation!);
         _currentVesselAnnotation = new VesselAnnotation();
@@ -333,6 +347,10 @@
         _completionTitle = "Success";
         _completionMessage = "Your blood vessel tree has been successfully completed";
         _showCompletionDialog = true;
+
+     
+
+
         StateHasChanged();
 
         PrecomputeAnnotations();
@@ -403,6 +421,7 @@
         public List<VesselPoint?> Points { get; } = new();
         public List<VesselSegment> Segments { get; } = new();
         public string Description { get; set; } = "";
+        public string Type { get; set; } = "";
     }
 
     [Inject] private IJSRuntime JsRuntime { get; set; } = default!;

--- a/Annotations.Blazor/Components/Pages/Annotations/AnnotateOnImage.razor
+++ b/Annotations.Blazor/Components/Pages/Annotations/AnnotateOnImage.razor
@@ -18,7 +18,7 @@
                     @if (_completionTitle == "Success")
                     {
                         <p>
-                            <MatTextField @bind-Value="_currentVesselAnnotation.Description"
+                            <MatTextField @bind-Value="_currentVesselAnnotation!.Description"
                                           Label="Annotation"
                                           FullWidth="true"
                                           Immediate="true"
@@ -67,7 +67,7 @@
                         </div>
                         <div class="MatOverwriteMarginTop50">
                             <p>Choose a type here</p>
-                            <MatRadioGroup @bind-Value="@_currentVesselAnnotation.Type">
+                            <MatRadioGroup @bind-Value="@_currentVesselAnnotation!.Type">
                                 <div>
                                     <MatRadioButton TValue="string">Arteries</MatRadioButton>
                                 </div>
@@ -231,14 +231,11 @@
 
 @code {
     private string? _currentUrl;
-    private bool _arteriesMarked;
-    private bool _veinsMarked;
 
     private bool _showCompletionDialog;
     private string _completionMessage = "";
     private string _completionTitle = "";
 
-    private bool _showTextField;
     private bool _showSegmentDialog;
 
     private VesselPoint? _draggedPoint;
@@ -251,7 +248,6 @@
     private List<VesselSegment> _drawableSegments = new();
     private List<VesselPoint> _drawablePoints = new();
 
-    private string _currentVesselType = "";
     private double _currentThickness = 0.0;
 
     private ElementReference _imageContainer;
@@ -331,16 +327,10 @@
         }
 
         _currentPoint.isVisible = true;
-        _showTextField = false;
         StateHasChanged();
         PrecomputeAnnotations();
     }
-
-    private void CancelPointAnnotation()
-    {
-        _showTextField = false;
-        StateHasChanged();
-    }
+    
 
     private void SaveSegmentAnnotation()
     {
@@ -366,7 +356,7 @@
             return;
         }
         
-        if (_currentVesselAnnotation.Type == "")
+        if (_currentVesselAnnotation!.Type == "")
         {
             _completionTitle = "Fail";
             _completionMessage = "Please choose a type.";

--- a/Annotations.Blazor/Components/Pages/Annotations/AnnotateOnImage.razor
+++ b/Annotations.Blazor/Components/Pages/Annotations/AnnotateOnImage.razor
@@ -29,7 +29,8 @@
                     }
                 </MatDialogContent>
                 <MatDialogActions>
-                    <MatButton OnClick="@(() => _showCompletionDialog = false)">OK</MatButton>
+
+                    <MatButton OnClick="@(() => { _showCompletionDialog = false; StateHasChanged();})">OK</MatButton>
                 </MatDialogActions>
             </MatDialog>
 
@@ -114,6 +115,17 @@
                                 <div class="MatOverwriteDecisions">
                                     <MatButton>Skip</MatButton>
                                     <MatButton OnClick="CompleteCurrentVessel" class="MatOverwriteButton">Complete</MatButton>
+                                </div>
+                                <div>
+                                    <h4>VirtualScroll with items</h4>
+                                    <MatVirtualScroll Items="_savedVessels" ItemType="VesselAnnotation" ItemHeight="50" Style="height: 500px">
+                                        <ItemTemplate>
+                                            <div>
+                                                @context.Description
+                                            </div>
+                                        </ItemTemplate>
+                                    </MatVirtualScroll>
+
                                 </div>
                             </div>
                         </div>
@@ -352,13 +364,12 @@
         _completionTitle = "Success";
         _completionMessage = "Your blood vessel tree has been successfully completed";
         _showCompletionDialog = true;
+        
 
-     
 
-
-        StateHasChanged();
 
         PrecomputeAnnotations();
+        StateHasChanged();
     }
 
     private async Task HandleImageClick(MouseEventArgs e)

--- a/Annotations.Blazor/Components/Pages/Annotations/AnnotateOnImage.razor
+++ b/Annotations.Blazor/Components/Pages/Annotations/AnnotateOnImage.razor
@@ -130,20 +130,22 @@
 
                                 @foreach (var segment in _drawableSegments)
                                 {
-                                    <line x1="@segment.StartPoint!.X" y1="@segment.StartPoint.Y"
-                                          x2="@segment.EndPoint!.X" y2="@segment.EndPoint.Y"
-                                          stroke="transparent"
-                                          stroke-width="20"
-                                          @onclick="@(() => HandleSegmentClick(segment))"
-                                          pointer-events="visibleStroke"/>
+                                    if (segment.isVisible)
+                                    {
+                                        <line x1="@segment.StartPoint!.X" y1="@segment.StartPoint.Y"
+                                              x2="@segment.EndPoint!.X" y2="@segment.EndPoint.Y"
+                                              stroke="transparent"
+                                              stroke-width="20"
+                                              @onclick="@(() => HandleSegmentClick(segment))"
+                                              pointer-events="visibleStroke"/>
 
-                                    <line x1="@segment.StartPoint.X" y1="@segment.StartPoint.Y"
-                                          x2="@segment.EndPoint.X" y2="@segment.EndPoint.Y"
-                                          stroke="white"
-                                          stroke-width="2"
-                                          pointer-events="none"/>
+                                        <line x1="@segment.StartPoint.X" y1="@segment.StartPoint.Y"
+                                              x2="@segment.EndPoint.X" y2="@segment.EndPoint.Y"
+                                              stroke="white"
+                                              stroke-width="2"
+                                              pointer-events="none"/>
+                                    }
                                 }
-
                                 @foreach (var point in _drawablePoints)
                                 {
                                     if (point.isVisible)
@@ -195,18 +197,34 @@
                                 var i1 = i;
                                 <MatExpansionPanel>
                                     <MatExpansionPanelSummary>
-
                                         <MatExpansionPanelHeader> Tree @i1 </MatExpansionPanelHeader>
                                     </MatExpansionPanelSummary>
                                     <MatExpansionPanelDetails>
+                                        <h6>Vessel Points</h6>
                                         @for (var j = 0; j < _savedVessels[i1].Points.Count; j++)
                                         {
                                             var j1 = j;
                                             var point = _savedVessels[i1].Points[j1];
-                                            <p> point @j </p>
-                                            
-                                            <MatIconButton Icon="visibility_off" ToggleIcon="visibility" @bind-Toggled = "@point!.isVisible">
-                                            </MatIconButton>
+                                            <p>
+                                                 point @j
+                                                <MatIconButton Icon="visibility_off" ToggleIcon="visibility" @bind-Toggled="@point!.isVisible">
+                                                </MatIconButton>
+                                            </p>
+
+
+                                        }
+                                        <h6>Vessel Segments</h6>
+                                        @for (var j = 0; j < _savedVessels[i1].Segments.Count; j++)
+                                        {
+                                            var j1 = j;
+                                            var segment = _savedVessels[i1].Segments[j1];
+                                            <p>
+                                                 segment @j
+                                                <MatIconButton Icon="visibility_off" ToggleIcon="visibility" @bind-Toggled="@segment!.isVisible">
+                                                </MatIconButton>
+                                            </p>
+
+
                                         }
                                     </MatExpansionPanelDetails>
                                 </MatExpansionPanel>
@@ -326,6 +344,7 @@
                     Thickness = _currentThickness,
                     Text = _currentPoint.Text
                 };
+                segment.isVisible = true;
                 _currentVesselAnnotation.Segments.Add(segment);
             }
         }
@@ -445,6 +464,7 @@
 
     private class VesselSegment
     {
+        public bool isVisible;
         public VesselPoint? StartPoint { get; set; }
         public VesselPoint? EndPoint { get; set; }
         public string Text { get; set; } = "";
@@ -461,10 +481,5 @@
     }
 
     [Inject] private IJSRuntime JsRuntime { get; set; } = default!;
-
-    private void toggleVisibillity(MouseEventArgs obj)
-    {
-        throw new NotImplementedException();
-    }
-
+    
 }

--- a/Annotations.Blazor/Components/Pages/Annotations/AnnotateOnImage.razor
+++ b/Annotations.Blazor/Components/Pages/Annotations/AnnotateOnImage.razor
@@ -88,7 +88,7 @@
                             </MatRadioGroup>
                         </div>
                         </div>
-                    <div class="mat-layout-grid-cell mat-layout-grid-cell-span-10">
+                    <div class="mat-layout-grid-cell mat-layout-grid-cell-span-8">
                         <div class="mat-layout-grid-inner">
                             <div class="mat-layout-grid-cell mat-layout-grid-cell-span-3">
                                 <div class="MatOverwriteIdentification">
@@ -115,17 +115,6 @@
                                 <div class="MatOverwriteDecisions">
                                     <MatButton>Skip</MatButton>
                                     <MatButton OnClick="CompleteCurrentVessel" class="MatOverwriteButton">Complete</MatButton>
-                                </div>
-                                <div>
-                                    <h4>VirtualScroll with items</h4>
-                                    <MatVirtualScroll Items="_savedVessels" ItemType="VesselAnnotation" ItemHeight="50" Style="height: 500px">
-                                        <ItemTemplate>
-                                            <div>
-                                                @context.Description
-                                            </div>
-                                        </ItemTemplate>
-                                    </MatVirtualScroll>
-
                                 </div>
                             </div>
                         </div>
@@ -195,6 +184,26 @@
                                 }
                             </svg>
                         </div>
+                    </div>
+                    <div class="mat-layout-grid-cell mat-layout-grid-cell-span-2">
+                        <MatAccordion Multi="true">
+                            @for (var i = 0; i < _savedVessels.Count; i++)
+                            {
+                                var i1 = i;
+                                <MatExpansionPanel>
+                                    <MatExpansionPanelSummary>
+                                        <MatExpansionPanelHeader> Tree @i1 </MatExpansionPanelHeader>
+                                    </MatExpansionPanelSummary>
+                                    <MatExpansionPanelDetails>
+                                        @for (var j = 0; j < _savedVessels[i1].Points.Count; j++)
+                                        {
+                                            var j1 = j;
+                                            <p> point @j </p>
+                                        }
+                                    </MatExpansionPanelDetails>
+                                </MatExpansionPanel>
+                            }
+                        </MatAccordion>
                     </div>
                 </div>
             </div>

--- a/Annotations.Blazor/Components/Pages/Annotations/AnnotateOnImage.razor
+++ b/Annotations.Blazor/Components/Pages/Annotations/AnnotateOnImage.razor
@@ -38,23 +38,12 @@
                 <MatDialogTitle>Blood vessel segment annotation</MatDialogTitle>
                 <MatDialogContent>
                     <p>
-                        <MatTextField @bind-Value="_currentSegment.Text"
-                                      Label="Annotation"
-                                      FullWidth="true"
-                                      Immediate="true"
-                                      class="MatOverwriteWhiteBG">
-                        </MatTextField>
-                    </p>
-                    <p>
                         <MatTextField @bind-Value="_currentSegment.Thickness"
                                       Label="Blood vessel thickness"
                                       FullWidth="true"
                                       Immediate="true"
                                       class="MatOverwriteWhiteBG">
                         </MatTextField>
-                    </p>
-                    <p>
-                        <MatSelectItem @bind-Value="@_currentSegment.Type" Label="Type" Items="@_types"></MatSelectItem>
                     </p>
                 </MatDialogContent>
                 <MatDialogActions>
@@ -267,12 +256,6 @@
 
     private ElementReference _imageContainer;
 
-    private string[] _types =
-    [
-        "Artery",
-        "Vein",
-        "Flow direction"
-    ];
 
     MatTheme _theme = new MatTheme()
     {
@@ -340,9 +323,7 @@
                 {
                     StartPoint = lastPoint,
                     EndPoint = _currentPoint,
-                    Type = _currentVesselType,
                     Thickness = _currentThickness,
-                    Text = _currentPoint.Text
                 };
                 segment.isVisible = true;
                 _currentVesselAnnotation.Segments.Add(segment);
@@ -419,7 +400,6 @@
         {
             X = (int)(e.ClientX - rect.Left),
             Y = (int)(e.ClientY - rect.Top),
-            Type = _currentVesselType
         };
 
         SavePointAnnotation(lastPoint);
@@ -458,8 +438,6 @@
         public bool isVisible;
         public int X { get; set; }
         public int Y { get; set; }
-        public string Text { get; set; } = "";
-        public string Type { get; set; } = "";
     }
 
     private class VesselSegment
@@ -467,9 +445,7 @@
         public bool isVisible;
         public VesselPoint? StartPoint { get; set; }
         public VesselPoint? EndPoint { get; set; }
-        public string Text { get; set; } = "";
         public double Thickness { get; set; } = 1.0;
-        public string Type { get; set; } = "";
     }
 
     private class VesselAnnotation

--- a/Annotations.Blazor/Components/Pages/Annotations/AnnotateOnImage.razor
+++ b/Annotations.Blazor/Components/Pages/Annotations/AnnotateOnImage.razor
@@ -76,9 +76,14 @@
                             </div>
                         </div>
                         <div class="MatOverwriteMarginTop50">
+                            <p>Choose a type here</p>
                             <MatRadioGroup @bind-Value="@_currentVesselAnnotation.Type">
-                                <MatRadioButton TValue="string">Arteries</MatRadioButton>
-                                <MatRadioButton TValue="string">Veins</MatRadioButton>
+                                <div>
+                                    <MatRadioButton TValue="string">Arteries</MatRadioButton>
+                                </div>
+                                <div>
+                                    <MatRadioButton TValue="string">Veins</MatRadioButton>
+                                </div>
                             </MatRadioGroup>
                         </div>
                         

--- a/Annotations.Blazor/wwwroot/matBlazorOverwrites.css
+++ b/Annotations.Blazor/wwwroot/matBlazorOverwrites.css
@@ -41,8 +41,8 @@
 }
 
 .MatOverwriteWorkImage {
-    width: 1000px !important;
-    height: 600px !important;
+    width: 100% !important;
+    height: 100% !important;
     pointer-events: auto !important;
 }
 


### PR DESCRIPTION
Refined some of the drawing features on the annotations page, as requested by the PO. 
- You can now only annotate on an entire tree. 
- You specify the type of tree on the check box on the left side. 
- Less popups when drawing trees.  
- Ability to toggle and untoggle parts of a tree 
- Can add branches to a tree when drawing
- deleted some code that isnt used anymore, and cleared warnings 