### PR TITLE
Changed page position from fixed to absolute

### DIFF
--- a/Annotations.Blazor/Components/Layout/MainLayout.razor.css
+++ b/Annotations.Blazor/Components/Layout/MainLayout.razor.css
@@ -79,7 +79,7 @@
 
 
 .page {
-    position: fixed;
+    position: absolute;
     display: flex;
     min-width: 100%;
     flex-direction: column;


### PR DESCRIPTION
Co-authored-by: Nickie Almind <nalm@itu.dk>

# Known bug:
No scroll enabled on any sites

# Bug occured:
On the branch implementing nav menu, when the div for page was changed from position: relative to position: fixed. This was done because the relative page would 'jump' when opening the nav menu.

# Fix:
Changing position to absolute