### PR TITLE
Feature/pt 70 segment width

### DIFF
--- a/Annotations.Blazor.Client/Pages/AnnotationTools/AnnotateOnImage.razor
+++ b/Annotations.Blazor.Client/Pages/AnnotationTools/AnnotateOnImage.razor
@@ -8,7 +8,7 @@
 @inject IAnnotationDataAccessor dataAccessor
 @inject NavigationManager Navigation
 @attribute [Authorize(Roles = "Administrator, Manager, AnnotationsUser")]
-
+@inject AuthenticationStateProvider AuthenticationStateProvider
 
 
 <PageTitle>Annotations</PageTitle>
@@ -76,9 +76,9 @@
                         <div class="MatOverwriteGrid">
                             <img src="img/billede1.png" alt="Profile Picture" class="MatOverwriteProfilePic">
                             <div>
-                                <b>Jane Doe</b>
+                                <b>@userInfo!.Name</b>
                                 <br/>
-                                <small>Surgeon</small>
+                                <small>@userInfo.Role</small>
                             </div>
                         </div>
                         @* RadioButtons for selecting Annotation types. Radiobuttons ensure that only one button can be on at once *@
@@ -287,6 +287,7 @@
     private string _completionTitle = "";
 
     private bool _showSegmentDialog;
+    private UserInfo? userInfo;
     
     // The image on this page is a locally stored, hardcoded image, because
     // the uploaded images are currently saved on a user-local azurite instance.
@@ -349,6 +350,14 @@
     /// </summary>
     protected override async Task OnInitializedAsync()
     {
+        var authState = await AuthenticationStateProvider.GetAuthenticationStateAsync();
+        var user = authState.User;
+
+        if (user.Identity?.IsAuthenticated == true)
+        {
+            userInfo = UserInfo.FromClaimsPrincipal(user);
+        }
+        
         _currentUrl = Navigation.Uri;
         Navigation.LocationChanged += OnLocationChanged;
         

--- a/Annotations.Blazor.Client/Pages/AnnotationTools/AnnotateOnImage.razor
+++ b/Annotations.Blazor.Client/Pages/AnnotationTools/AnnotateOnImage.razor
@@ -72,17 +72,18 @@
             <div class="mat-layout-grid">
                 <div class="mat-layout-grid-inner">
                     <div class="mat-layout-grid-cell mat-layout-grid-cell-span-2">
-                        @* Shows userdata in the left corner (currently hardcoded) *@
+                        @* Shows userdata in the left corner *@
                         <div class="MatOverwriteGrid">
                             <img src="img/billede1.png" alt="Profile Picture" class="MatOverwriteProfilePic">
-                            <div>
+                            <div style="padding: 1rem">
                                 <b>@userInfo!.Name</b>
                                 <br/>
                                 <small>@userInfo.Role</small>
                             </div>
                         </div>
+                        <MatDivider Style="margin-top: 10%; margin-bottom: 10%"></MatDivider>
                         @* RadioButtons for selecting Annotation types. Radiobuttons ensure that only one button can be on at once *@
-                        <div class="MatOverwriteMarginTop50">
+                        <div>
                             <p>Choose a type here</p>
                             <MatRadioGroup @bind-Value="@_currentVesselAnnotation!.Type">
                                 <div>
@@ -90,6 +91,22 @@
                                 </div>
                                 <div>
                                     <MatRadioButton Value="@("Veins")" TValue="string">Veins</MatRadioButton>
+                                </div>
+                            </MatRadioGroup>
+                        </div>
+                        <MatDivider Style="margin-top: 10%; margin-bottom: 10%"></MatDivider>
+                        @* RadioButtons for selecting Blood Vessel Thickness. *@
+                        <div>
+                            <p>Blood vessel thickness</p>
+                            <MatRadioGroup @bind-Value="@_currentThickness">
+                                <div>
+                                    <MatRadioButton Value="@(1.0)" TValue="double">Small</MatRadioButton>
+                                </div>
+                                <div>
+                                    <MatRadioButton Value="@(3.0)" TValue="double">Medium</MatRadioButton>
+                                </div>                            
+                                <div>
+                                    <MatRadioButton Value="@(5.0)" TValue="double">Large</MatRadioButton>
                                 </div>
                             </MatRadioGroup>
                         </div>

--- a/Annotations.Blazor.Client/Pages/AnnotationTools/AnnotateOnImage.razor
+++ b/Annotations.Blazor.Client/Pages/AnnotationTools/AnnotateOnImage.razor
@@ -75,7 +75,7 @@
                         @* Shows userdata in the left corner *@
                         <div class="MatOverwriteGrid">
                             <img src="img/billede1.png" alt="Profile Picture" class="MatOverwriteProfilePic">
-                            <div style="padding: 1rem">
+                            <div>
                                 <b>@userInfo!.Name</b>
                                 <br/>
                                 <small>@userInfo.Role</small>

--- a/Annotations.Blazor.Client/Pages/AnnotationTools/AnnotateOnImage.razor
+++ b/Annotations.Blazor.Client/Pages/AnnotationTools/AnnotateOnImage.razor
@@ -236,33 +236,36 @@
                                             </div>
                                         </MatExpansionPanelHeader>
                                     </MatExpansionPanelSummary>
-                                    <MatExpansionPanelDetails>
-                                        <h6>Vessel Points</h6>
-                                        @for (var j = 0; j < _savedVessels[i1].Points.Count; j++)
-                                        {
-                                            var j1 = j;
-                                            var point = _savedVessels[i1].Points[j1];
-                                            <p>
-                                                point @j
-                                                @* Visibility button that can be clicked to toggle/ untoggle points 
+                                    @if (_savedVessels[i1].IsVisible)
+                                    {
+                                        <MatExpansionPanelDetails>
+                                            <h6>Vessel Points</h6>
+                                            @for (var j = 0; j < _savedVessels[i1].Points.Count; j++)
+                                            {
+                                                var j1 = j;
+                                                var point = _savedVessels[i1].Points[j1];
+                                                <p>
+                                                    point @j
+                                                    @* Visibility button that can be clicked to toggle/ untoggle points 
                                                    MatIconButton is chosen because its easy to change/ use icons with *@
-                                                <MatIconButton Icon="visibility_off" ToggleIcon="visibility" @bind-Toggled="@point.IsVisible">
-                                                </MatIconButton>
-                                            </p>
-                                        }
-                                        <h6>Vessel Segments</h6>
-                                        @for (var j = 0; j < _savedVessels[i1].Segments.Count; j++)
-                                        {
-                                            var j1 = j;
-                                            var segment = _savedVessels[i1].Segments[j1];
-                                            <p>
-                                                segment @j
-                                                @* Visibility button that can be clicked to toggle/ untoggle segments *@
-                                                <MatIconButton Icon="visibility_off" ToggleIcon="visibility" @bind-Toggled="@segment.IsVisible">
-                                                </MatIconButton>
-                                            </p>
-                                        }
-                                    </MatExpansionPanelDetails>
+                                                    <MatIconButton Icon="visibility_off" ToggleIcon="visibility" @bind-Toggled="@point.IsVisible">
+                                                    </MatIconButton>
+                                                </p>
+                                            }
+                                            <h6>Vessel Segments</h6>
+                                            @for (var j = 0; j < _savedVessels[i1].Segments.Count; j++)
+                                            {
+                                                var j1 = j;
+                                                var segment = _savedVessels[i1].Segments[j1];
+                                                <p>
+                                                    segment @j
+                                                    @* Visibility button that can be clicked to toggle/ untoggle segments *@
+                                                    <MatIconButton Icon="visibility_off" ToggleIcon="visibility" @bind-Toggled="@segment.IsVisible">
+                                                    </MatIconButton>
+                                                </p>
+                                            }
+                                        </MatExpansionPanelDetails>
+                                    }
                                 </MatExpansionPanel>
                             }
                         </MatAccordion>

--- a/Annotations.Blazor.Client/Pages/AnnotationTools/AnnotateOnImage.razor
+++ b/Annotations.Blazor.Client/Pages/AnnotationTools/AnnotateOnImage.razor
@@ -55,7 +55,7 @@
                                 <MatRadioButton Value="@(3.0)" TValue="double">Medium</MatRadioButton>
                             </div>                            
                             <div>
-                                <MatRadioButton Value="@(4.5)" TValue="double">Large</MatRadioButton>
+                                <MatRadioButton Value="@(5.0)" TValue="double">Large</MatRadioButton>
                             </div>
                         </MatRadioGroup>
                     </p>

--- a/Annotations.Blazor.Client/Pages/AnnotationTools/AnnotateOnImage.razor
+++ b/Annotations.Blazor.Client/Pages/AnnotationTools/AnnotateOnImage.razor
@@ -52,10 +52,10 @@
                                 <MatRadioButton Value="@(1.0)" TValue="double">Small</MatRadioButton>
                             </div>
                             <div>
-                                <MatRadioButton Value="@(2.0)" TValue="double">Medium</MatRadioButton>
+                                <MatRadioButton Value="@(3.0)" TValue="double">Medium</MatRadioButton>
                             </div>                            
                             <div>
-                                <MatRadioButton Value="@(4.0)" TValue="double">Large</MatRadioButton>
+                                <MatRadioButton Value="@(4.5)" TValue="double">Large</MatRadioButton>
                             </div>
                         </MatRadioGroup>
                     </p>
@@ -327,7 +327,7 @@
     private List<VesselSegmentModel> _drawableSegments = new();
     private List<VesselPointModel> _drawablePoints = new();
 
-    private double _currentThickness = 0.0;
+    private double _currentThickness = 1.0;
 
     // References the image container used in the html portion (bounded to the @ref tag)
     // This is to bypass issues with JavaScript on a Blazor application.

--- a/Annotations.Blazor.Client/Pages/AnnotationTools/AnnotateOnImage.razor
+++ b/Annotations.Blazor.Client/Pages/AnnotationTools/AnnotateOnImage.razor
@@ -47,12 +47,17 @@
                 <MatDialogTitle>Blood vessel segment annotation</MatDialogTitle>
                 <MatDialogContent>
                     <p>
-                        <MatTextField @bind-Value="_currentSegment!.Thickness"
-                                      Label="Blood vessel thickness"
-                                      FullWidth="true"
-                                      Immediate="true"
-                                      class="MatOverwriteWhiteBG">
-                        </MatTextField>
+                        <MatRadioGroup @bind-Value="@_currentSegment!.Thickness">
+                            <div>
+                                <MatRadioButton Value="@(1.0)" TValue="double">Small</MatRadioButton>
+                            </div>
+                            <div>
+                                <MatRadioButton Value="@(2.0)" TValue="double">Medium</MatRadioButton>
+                            </div>                            
+                            <div>
+                                <MatRadioButton Value="@(4.0)" TValue="double">Large</MatRadioButton>
+                            </div>
+                        </MatRadioGroup>
                     </p>
                 </MatDialogContent>
                 <MatDialogActions>
@@ -152,7 +157,7 @@
                                         <line x1="@segment.StartPoint.X" y1="@segment.StartPoint.Y"
                                               x2="@segment.EndPoint.X" y2="@segment.EndPoint.Y"
                                               stroke="white"
-                                              stroke-width="2"
+                                              stroke-width=@segment.Thickness
                                               pointer-events="none"/>
                                     }
 
@@ -180,7 +185,7 @@
                                         <line x1="@segment.StartPoint.X" y1="@segment.StartPoint.Y"
                                               x2="@segment.EndPoint.X" y2="@segment.EndPoint.Y"
                                               stroke="@(_currentSegment == segment ? "red" : "white")"
-                                              stroke-width="2"
+                                              stroke-width=@segment.Thickness
                                               pointer-events="none"/>
                                     }
 
@@ -302,7 +307,7 @@
         Id = 0,
         StartPoint = null!,
         EndPoint = null!,
-        Thickness = 0,
+        Thickness = 1.0,
         IsVisible = true
     };
 

--- a/Annotations.Blazor.Client/Pages/Home/PersonalHome.razor
+++ b/Annotations.Blazor.Client/Pages/Home/PersonalHome.razor
@@ -3,7 +3,10 @@
 @page "/home/{userid}"
 @attribute [Authorize(Roles = "Administrator, Manager, AnnotationsUser")]
 @namespace Home
+@using Annotations.Blazor.Client
 @using Microsoft.AspNetCore.Authorization
+@inject AuthenticationStateProvider AuthenticationStateProvider
+
 
 <style>
     .mat-layout-grid-cell{
@@ -22,7 +25,7 @@
     }
 
 </style>
-<h2> Welcome user</h2>
+<h2> Welcome @userInfo!.Name</h2>
 <div class="mat-layout-grid mat-layout-grid-align-left mat-layout-grid-cell-span-3">
     <div class="mat-layout-grid-inner">
 
@@ -72,9 +75,9 @@
                     <div class = "personal-style">
                         <b>Personal Information</b>
                         <br/>
-                        Jane Doe
+                        @userInfo!.Name
                         <br/>
-                        Surgeon at Frederiksberg Hospital
+                        @userInfo.Role
                         <br/>
                     </div>
                 </div>
@@ -90,14 +93,23 @@
 
 @code {
     private string? currentUrl;
+    private UserInfo? userInfo;
 
     MatTheme theme = new MatTheme()
     {
         Primary = MatThemeColors.Green._800.Value
     };
 
-    protected override void OnInitialized()
+    protected override async Task OnInitializedAsync ()
     {
+        var authState = await AuthenticationStateProvider.GetAuthenticationStateAsync();
+        var user = authState.User;
+
+        if (user.Identity?.IsAuthenticated == true)
+        {
+            userInfo = UserInfo.FromClaimsPrincipal(user);
+        }
+        
         currentUrl = Navigation.Uri;
         Navigation.LocationChanged += HandleLocationChanged;
     }

--- a/Annotations.Blazor.Tests/E2E/UserDataPlaywrightTest.cs
+++ b/Annotations.Blazor.Tests/E2E/UserDataPlaywrightTest.cs
@@ -1,0 +1,39 @@
+﻿using System.Threading.Tasks;
+using Microsoft.Playwright;
+using Microsoft.Playwright.Xunit;
+
+namespace Annotations.Blazor.Tests.E2E;
+
+public class UserDataPlaywrightTest : PageTest
+{
+    
+    private const string AuthStatePath = "../../../../playwright/.auth/orchard-state-with-AnnotationsUser.json";
+    
+    public override BrowserNewContextOptions ContextOptions()
+    {
+        return new BrowserNewContextOptions
+        {
+            StorageStatePath = AuthStatePath
+        };
+    }
+    
+    [Fact]
+    public async Task UserInfoOnPersonalHomePageTest()
+    {
+        await Page.GotoAsync("https://localhost:7238/");
+        await Page.GetByRole(AriaRole.Heading, new() { Name = "Welcome" }).ClickAsync();
+        await Page.GetByText("Personal Information testUserAnnotationsUser AnnotationsUser").ClickAsync();
+
+    }
+    
+    [Fact]
+    public async Task UserInfoOnAnnotationsPageTest()
+    {
+        await Page.GotoAsync("https://localhost:7238/images/annotations");
+        await Page.GetByText("testUserAnnotationsUser").ClickAsync();
+        await Page.GetByText("AnnotationsUser", new() { Exact = true }).ClickAsync();
+        
+    }
+    
+    
+}

--- a/Annotations.Blazor.Tests/Unit/AnnotateOnImageTests.cs
+++ b/Annotations.Blazor.Tests/Unit/AnnotateOnImageTests.cs
@@ -1,6 +1,8 @@
 ﻿using Annotations.Blazor.Client.Pages.AnnotationTools;
 using Annotations.Blazor.Client.Services;
 using Microsoft.AspNetCore.Http;
+using System.Security.Claims;
+using Annotations.Blazor.Client;
 
 
 namespace Annotations.Blazor.Tests.Unit;
@@ -14,11 +16,21 @@ public class AnnotateOnImageTests : TestContext
         // Arrange
         JSInterop.Mode = JSRuntimeMode.Loose; // allows JS to run during bUnit tests
         var authContext = this.AddTestAuthorization();
+        
+        var claims = new[]
+        {
+            new Claim(UserInfo.UserIdClaimType, "test-user-id"),
+            new Claim(UserInfo.NameClaimType, "FAKE USER TEST"),
+            new Claim(UserInfo.RoleClaimType, "test-role")
+        };
+        
         authContext.SetAuthorized("", AuthorizationState.Unauthorized); // fakes authorized state for a fake user
+        authContext.SetClaims(claims);
         
         Services.AddSingleton<IAnnotationDataAccessor, AnnotationDataAccessor>();
         Services.AddSingleton<IHttpContextAccessor, HttpContextAccessor>();
         Services.AddHttpClient();
+        
         
         // Act
         var annotatePage = RenderComponent<AnnotateOnImage>();
@@ -34,7 +46,14 @@ public class AnnotateOnImageTests : TestContext
         // Arrange
         JSInterop.Mode = JSRuntimeMode.Loose; // allows JS to run during bUnit tests
         var authContext = this.AddTestAuthorization();
-        authContext.SetAuthorized("FAKE USER TEST"); // fakes authorized state for a fake user
+        var claims = new[]
+        {
+            new Claim(UserInfo.UserIdClaimType, "test-user-id"),
+            new Claim(UserInfo.NameClaimType, "FAKE USER TEST"),
+            new Claim(UserInfo.RoleClaimType, "test-role")
+        };
+        authContext.SetAuthorized("FAKE USER TEST");
+        authContext.SetClaims(claims);// fakes authorized state for a fake user
         
         Services.AddSingleton<IAnnotationDataAccessor, AnnotationDataAccessor>();
         Services.AddSingleton<IHttpContextAccessor, HttpContextAccessor>();

--- a/Annotations.Blazor.Tests/Unit/PersonalHomeTests.cs
+++ b/Annotations.Blazor.Tests/Unit/PersonalHomeTests.cs
@@ -1,3 +1,6 @@
+using System.Security.Claims;
+using Annotations.Blazor.Client;
+
 namespace Annotations.Blazor.Tests.Unit;
 
 public class PersonalHomeTests : TestContext
@@ -16,6 +19,30 @@ public class PersonalHomeTests : TestContext
         // Assert
         homePage.Find("h1").MarkupMatches("<h1>Annotations - PerfusionTech</h1>");
         homePage.Find("p").MarkupMatches("<p> Log in or make a new account to get access</p>");
+    }
+    
+    [Fact]
+    public void AuthorizedTest()
+    {
+        // Arrange
+        JSInterop.Mode = JSRuntimeMode.Loose; // allows JS to run during bUnit tests
+        var authContext = this.AddTestAuthorization();
+        
+        var claims = new[]
+        {
+            new Claim(UserInfo.UserIdClaimType, "test-user-id"),
+            new Claim(UserInfo.NameClaimType, "FAKE USER TEST"),
+            new Claim(UserInfo.RoleClaimType, "test-role")
+        };
+        
+        authContext.SetAuthorized("FAKE TEST USER"); // fakes authorized state for a fake user
+        authContext.SetClaims(claims);
+        
+        // Act
+        var homePage = RenderComponent<Home.Home>();
+        
+        // Assert
+        homePage.Find("h2").MarkupMatches("<h2> Welcome FAKE USER TEST</h2>");
     }
 
 }

--- a/Annotations.Blazor.Tests/Unit/PersonalHomeTests.cs
+++ b/Annotations.Blazor.Tests/Unit/PersonalHomeTests.cs
@@ -17,19 +17,5 @@ public class PersonalHomeTests : TestContext
         homePage.Find("h1").MarkupMatches("<h1>Annotations - PerfusionTech</h1>");
         homePage.Find("p").MarkupMatches("<p> Log in or make a new account to get access</p>");
     }
-    
-    [Fact]
-    public void AuthorizedTest()
-    {
-        // Arrange
-        JSInterop.Mode = JSRuntimeMode.Loose; // allows JS to run during bUnit tests
-        var authContext = this.AddTestAuthorization();
-        authContext.SetAuthorized("FAKE TEST USER"); // fakes authorized state for a fake user
-        
-        // Act
-        var homePage = RenderComponent<Home.Home>();
-        
-        // Assert
-        homePage.Find("h2").MarkupMatches("<h2> Welcome user</h2>");
-    }
+
 }


### PR DESCRIPTION
Segment width is now shown on the annotation tool. There are 3 predefined widths to choose from. We have also removed the drop down menu showing points and segments, when the whole tree has been toggled invisible. Additionally, we added user name and user role to both annotations and home page. This has been tested with 2 playwright tests and a bunit test.